### PR TITLE
fix: trigger player head fetches only once at startup, not every 5 min

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -80,7 +80,8 @@ public class DashboardWebServer {
                     FabricDashboardMod.LOGGER.info("Found existing cache file at " + cacheFile.getAbsolutePath() + ". Skipping historical parse.");
                 }
 
-                // After parse, trigger head fetches for all known players
+                // Trigger head fetches once after the startup parse — not on every incremental update.
+                // New players discovered later will have their heads fetched on-demand by the FaceHandler.
                 triggerHeadFetches();
 
                 long delay = DashboardConfig.get().incremental_update_interval_minutes;
@@ -93,8 +94,6 @@ public class DashboardWebServer {
                         incLogsDir = new File(FabricLoader.getInstance().getGameDir().toFile(), "logs");
                     }
                     parser.runIncrementalParse(incLogsDir, cacheFile);
-                    // Re-check for new players after incremental parse
-                    triggerHeadFetches();
                 }, delay, delay, TimeUnit.MINUTES);
             });
 


### PR DESCRIPTION
## Problem
`triggerHeadFetches()` was being called at the end of every incremental parse cycle (default: every 5 minutes), causing a log spam of:
```
[pool-18-thread-1/INFO]: Triggering head fetches for 11 known players
```

## Root Cause
The call to `triggerHeadFetches()` was placed inside the `scheduleAtFixedRate` lambda alongside `runIncrementalParse()`. Since all known players are already present in the cache after the initial startup parse, re-scanning the cache and re-queuing fetches every 5 minutes served no purpose (the `PlayerHeadService` TTL cache would skip them all anyway, but not before printing the log line).

## Fix
Removed `triggerHeadFetches()` from the scheduled incremental update block. It now fires exactly once — right after the initial startup log parse completes.

New players who join after startup will still get their heads fetched on-demand via `FaceHandler.fetchIfNeeded()` the first time the dashboard is opened.