### PR TITLE
feat: Player Detail Sub-menu with 3D Skins and Stats

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/parser/DashboardData.java
+++ b/backend/src/main/java/com/playtime/dashboard/parser/DashboardData.java
@@ -12,5 +12,6 @@ public class DashboardData {
     public static class SessionData {
         public int sessions = 0;
         public double avg = 0.0;
+        public double longestSession = 0.0;
     }
 }

--- a/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
+++ b/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
@@ -262,6 +262,7 @@ public class LogParser {
         double totalMinutesCombined = sData.sessions * sData.avg;
         sData.sessions++;
         sData.avg = (totalMinutesCombined + sessionTotalMinutes) / sData.sessions;
+        sData.longestSession = Math.max(sData.longestSession, sessionTotalMinutes);
 
         // Distribute minutes to days/hours accurately
         LocalDateTime current = startTs;
@@ -307,6 +308,7 @@ public class LogParser {
         }
         for (DashboardData.SessionData sd : data.sessData.values()) {
             sd.avg = Math.round(sd.avg * 10.0) / 10.0;
+            sd.longestSession = Math.round(sd.longestSession * 10.0) / 10.0;
         }
         for (Map<String, double[]> map : data.hourly.values()) {
             for (double[] arr : map.values()) {

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -293,8 +293,8 @@ public class DashboardWebServer {
                 return;
             }
 
-            Map<String, String> colorMap = headService.getColorMap();
-            byte[] json = GSON.toJson(colorMap).getBytes(StandardCharsets.UTF_8);
+            Map<String, PlayerHeadService.PlayerMeta> metaMap = headService.getColorMap();
+            byte[] json = GSON.toJson(metaMap).getBytes(StandardCharsets.UTF_8);
 
             exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
             exchange.getResponseHeaders().set("Cache-Control", "public, max-age=60");

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
@@ -150,13 +150,9 @@ public class PlayerHeadService {
         return defaultHeadBytes;
     }
 
-    /** Returns the full color map (playerName → hex color string). */
-    public Map<String, String> getColorMap() {
-        Map<String, String> result = new HashMap<>();
-        for (Map.Entry<String, PlayerMeta> entry : metaMap.entrySet()) {
-            result.put(entry.getKey(), entry.getValue().colorHex);
-        }
-        return result;
+    /** Returns the full color map (playerName → PlayerMeta). */
+    public Map<String, PlayerMeta> getColorMap() {
+        return new HashMap<>(metaMap);
     }
 
     /** Shutdown the background executor cleanly. */

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -6,6 +6,7 @@
     <title>MC Server — Player Activity Heatmap</title>
     <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/skinview3d@3.0.0/dist/bundle.js"></script>
     <style>
       :root,[data-theme="light"]{
         --color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;
@@ -190,6 +191,57 @@
       .rank-2{background:oklch(0.82 0.04 240);color:oklch(0.4 0.06 240);}
       .rank-3{background:oklch(0.80 0.08 50);color:oklch(0.45 0.09 50);}
 
+      /* Player Detail Modal */
+      .modal-overlay {
+        position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+        background: rgba(0,0,0,0.6); backdrop-filter: blur(8px);
+        display: flex; align-items: center; justify-content: center;
+        z-index: 1000; opacity: 0; pointer-events: none;
+        transition: opacity 300ms cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .modal-overlay.visible { opacity: 1; pointer-events: auto; }
+      .modal-content {
+        background: var(--color-surface);
+        border: 1px solid oklch(from var(--color-text) l c h / 0.1);
+        border-radius: var(--radius-xl);
+        width: 90%; max-width: 840px; height: auto; max-height: 90dvh;
+        overflow-y: auto; position: relative;
+        transform: translateY(20px) scale(0.98);
+        transition: transform 400ms cubic-bezier(0.16, 1, 0.3, 1);
+        box-shadow: var(--shadow-lg);
+        display: grid; grid-template-columns: 320px 1fr;
+      }
+      @media (max-width: 768px) {
+        .modal-content { grid-template-columns: 1fr; }
+      }
+      .modal-overlay.visible .modal-content { transform: translateY(0) scale(1); }
+      .modal-close {
+        position: absolute; top: var(--space-4); right: var(--space-4);
+        width: 32px; height: 32px; border-radius: 50%;
+        display: flex; align-items: center; justify-content: center;
+        background: var(--color-surface-dynamic); border: 1px solid var(--color-border);
+        color: var(--color-text); cursor: pointer; z-index: 10;
+      }
+      .modal-viewer-side {
+        background: oklch(from var(--color-primary) 0.15 0.04 h);
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        padding: var(--space-8); position: relative;
+      }
+      #skinViewer { width: 100%; aspect-ratio: 1/1.2; cursor: grab; }
+      #skinViewer:active { cursor: grabbing; }
+      .modal-info-side { padding: var(--space-8); display: flex; flex-direction: column; gap: var(--space-6); }
+      .modal-player-header { display: flex; align-items: center; gap: var(--space-4); }
+      .modal-player-name { font-size: var(--text-xl); font-weight: 700; letter-spacing: -0.02em; }
+      .modal-stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--space-4); }
+      .stat-card {
+        background: var(--color-surface-2); border: 1px solid var(--color-divider);
+        padding: var(--space-4); border-radius: var(--radius-lg);
+        display: flex; flex-direction: column; gap: var(--space-1);
+      }
+      .stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-text-faint); font-weight: 700; }
+      .stat-value { font-size: var(--text-base); font-weight: 700; color: var(--color-text); }
+      .stat-icon { color: var(--color-primary); margin-bottom: var(--space-1); }
+
       @media(max-width:768px){
         .heatmap-section.panel-open{grid-template-columns:1fr;}
         header{padding:var(--space-3) var(--space-4);}
@@ -302,6 +354,28 @@
           <tbody id="playerTableBody"></tbody>
         </table>
       </div>
+
+      <div class="modal-overlay" id="playerModal">
+        <div class="modal-content">
+          <button class="modal-close" onclick="closePlayerModal()">✕</button>
+          <div class="modal-viewer-side">
+            <div id="skinViewer"></div>
+          </div>
+          <div class="modal-info-side">
+            <div class="modal-player-header">
+              <div id="modalPlayerHead"></div>
+              <div class="modal-player-name" id="modalPlayerName">PlayerName</div>
+            </div>
+            <div class="modal-stats-grid" id="modalStats">
+              <!-- Stats dynamic -->
+            </div>
+            <div style="margin-top:auto; font-size:var(--text-xs); color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-2);">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+              Calculated from latest server logs
+            </div>
+          </div>
+        </div>
+      </div>
     </main>
 
     <div class="tooltip" id="tooltip"></div>
@@ -334,7 +408,7 @@
       }
 
       // Dynamic player colors fetched from skin-derived data
-      let PLAYER_COLORS = {};
+      let PLAYER_META = {};
 
       // Returns an <img> tag for a player's Minecraft head
       function playerHead(name, size = 16) {
@@ -343,7 +417,7 @@
 
       // Returns a small color indicator (for contexts where images don't work, like chart.js)
       function playerColor(name) {
-        return PLAYER_COLORS[name] || '#888';
+        return (PLAYER_META[name] && PLAYER_META[name].colorHex) || '#888';
       }
 
       let playerTotals = {};
@@ -885,7 +959,7 @@
           const sd=sessData[p]||{};
           const avgMin=sd.avg||0;
           const avgFmt=avgMin<60?Math.round(avgMin)+'m':(avgMin/60).toFixed(1)+'h';
-          return `<tr>
+          return `<tr onclick="showPlayerDetails('${p}')" style="cursor:pointer;">
             <td style="display:flex;align-items:center;">
               <span style="display:inline-block;width:28px;text-align:left;flex-shrink:0;">${i<3?`<span class="rank-badge ${rankClass[i]||''}">${i+1}</span>`:''}</span>
               ${playerHead(p, 28)}
@@ -898,12 +972,101 @@
         }).join('');
       }
 
+      let skinViewer = null;
+
+      function closePlayerModal() {
+        document.getElementById('playerModal').classList.remove('visible');
+      }
+
+      function showPlayerDetails(name) {
+        const meta = PLAYER_META[name] || {};
+        const sd = sessData[name] || {};
+        
+        document.getElementById('modalPlayerName').textContent = name;
+        document.getElementById('modalPlayerHead').innerHTML = playerHead(name, 32);
+        
+        // Calculate stats
+        const totalMinutes = playerTotals[name] || 0;
+        
+        // Peak month
+        const monthly = {};
+        for (const [date, players] of Object.entries(playerDailyRaw)) {
+          if (players[name]) {
+            const m = date.substring(0, 7); // YYYY-MM
+            monthly[m] = (monthly[m] || 0) + players[name];
+          }
+        }
+        const peakMonth = Object.entries(monthly).sort((a,b) => b[1]-a[1])[0];
+        let peakMonthFmt = '-';
+        if (peakMonth) {
+          const [y, m] = peakMonth[0].split('-');
+          const mnames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+          peakMonthFmt = mnames[parseInt(m)-1] + ' ' + y;
+        }
+
+        // Peak hour
+        const hourlyAcc = new Array(24).fill(0);
+        for (const [date, players] of Object.entries(hourly)) {
+          if (players[name]) {
+            players[name].forEach((mins, h) => { hourlyAcc[h] += mins; });
+          }
+        }
+        const peakHourIdx = hourlyAcc.indexOf(Math.max(...hourlyAcc));
+        let peakHourFmt = '-';
+        if (Math.max(...hourlyAcc) > 0) {
+          const h = peakHourIdx % 12 || 12;
+          const ampm = peakHourIdx < 12 ? 'am' : 'pm';
+          peakHourFmt = h + ampm;
+        }
+
+        const stats = [
+          { label: 'Total Playtime', value: fmtHours(totalMinutes/60), icon: '⏱️' },
+          { label: 'Sessions', value: sd.sessions || '0', icon: '🎮' },
+          { label: 'Avg Session', value: sd.avg < 60 ? Math.round(sd.avg)+'m' : (sd.avg/60).toFixed(1)+'h', icon: '📊' },
+          { label: 'Longest Session', value: sd.longestSession ? (sd.longestSession < 60 ? Math.round(sd.longestSession)+'m' : (sd.longestSession/60).toFixed(1)+'h') : '-', icon: '🏆' },
+          { label: 'Peak Hour', value: peakHourFmt, icon: '🔥' },
+          { label: 'Most Active Month', value: peakMonthFmt, icon: '📅' }
+        ];
+
+        document.getElementById('modalStats').innerHTML = stats.map(s => `
+          <div class="stat-card">
+            <div class="stat-icon">${s.icon}</div>
+            <div class="stat-label">${s.label}</div>
+            <div class="stat-value">${s.value}</div>
+          </div>
+        `).join('');
+
+        // Show modal
+        const modal = document.getElementById('playerModal');
+        modal.classList.add('visible');
+
+        // Initialize/Update SkinViewer
+        if (!skinViewer) {
+          skinViewer = new skinview3d.SkinViewer({
+            canvas: document.createElement('canvas'),
+            width: 300,
+            height: 400,
+            animation: new skinview3d.WalkingAnimation()
+          });
+          document.getElementById('skinViewer').appendChild(skinViewer.canvas);
+        }
+        
+        // Load skin
+        const uuid = meta.uuid || name;
+        skinViewer.loadSkin(`https://crafatar.com/skins/${uuid}`);
+        skinViewer.animation.paused = false;
+      }
+
+      window.addEventListener('keydown', e => {
+        if (e.key === 'Escape') closePlayerModal();
+      });
+
       const rankClass = ['rank-1', 'rank-2', 'rank-3'];
 
       async function loadPlayerMeta() {
         try {
           const res = await fetch('/api/player-meta');
-          PLAYER_COLORS = await res.json();
+          PLAYER_META = await res.json();
         } catch(e) {
           console.warn('Could not load player meta, using fallback colors');
         }


### PR DESCRIPTION
This PR implements the Player Detail Sub-menu feature.

### Changes:
- **3D Skin Viewer**: Integrated `skinview3d` for animated player models in a new glassmorphic modal.
- **Advanced Stats**: Added "Longest Session", "Peak Hour", and "Most Active Month" to player profiles.
- **Backend Updates**: 
  - `SessionData` now tracks `longestSession`.
  - `PlayerHeadService` and `PlayerMetaHandler` now expose player UUIDs for skin fetching.
- **UX Improvements**: Clickable rows in the leaderboard table open the player profile.

Verified with `./gradlew build` and manual testing of the frontend.