### PR TITLE
fix: config hot-reloading and anti-cache headers

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,18 @@
+# Project Description
+Minecraft server activity dashboard — Java Fabric mod backend with an embedded HTTP server serving JSON and a vanilla HTML/JS frontend heatmap.
+
+# Code Conventions
+- **Java**: Standard Java formatting, Javadoc for public classes and endpoints
+- **JS/HTML**: Prettier formatting, no inline styles, semantic HTML
+- **Caching**: Use `Cache-Control: no-cache` headers for dynamic JSON and HTML. Append version strings (e.g., `?v=2`) to resource URLs when significant logic changes to force client-side refreshes.
+- **Filenames**: kebab-case for all new frontend and documentation files
+
+# Folder Conventions
+- `frontend/` — all HTML, CSS, JS single-source-of-truth assets
+- `backend/` — Java Fabric mod source, build.gradle, log parser, web server
+- `docs/` — README, ARCHITECTURE, CONTRIBUTING
+
+# Git Conventions
+- Conventional commits: feat / fix / chore / docs / refactor
+- Feature branches for any change touching more than one file
+- No direct push to main for behavior changes; open a PR instead

--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -24,9 +24,7 @@ public class DashboardConfig {
     private static DashboardConfig instance;
 
     public static DashboardConfig get() {
-        if (instance == null) {
-            load();
-        }
+        load();
         return instance;
     }
 

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -190,6 +190,9 @@ public class DashboardWebServer {
                 }
                 
                 exchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
+                exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+                exchange.getResponseHeaders().set("Pragma", "no-cache");
+                exchange.getResponseHeaders().set("Expires", "0");
                 exchange.sendResponseHeaders(200, 0);
                 
                 try (OutputStream os = exchange.getResponseBody()) {
@@ -352,7 +355,9 @@ public class DashboardWebServer {
             byte[] json = GSON.toJson(metaMap).getBytes(StandardCharsets.UTF_8);
 
             exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
-            exchange.getResponseHeaders().set("Cache-Control", "public, max-age=60");
+            exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+            exchange.getResponseHeaders().set("Pragma", "no-cache");
+            exchange.getResponseHeaders().set("Expires", "0");
             exchange.sendResponseHeaders(200, json.length);
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(json);
@@ -376,6 +381,9 @@ public class DashboardWebServer {
             }
             
             exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+            exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+            exchange.getResponseHeaders().set("Pragma", "no-cache");
+            exchange.getResponseHeaders().set("Expires", "0");
             
             if (!cacheFile.exists()) {
                 String emptyJson = "{\"daily\":{},\"playerDailyRaw\":{},\"sessData\":{},\"hourly\":{}}";


### PR DESCRIPTION
This PR addresses the persistence of ignored players and stale dashboard content by implementing hot-reloading for the configuration and disabling HTTP caching.

### Key Changes
1.  **Config Hot-Reloading**: Modified `DashboardConfig.get()` to reload the configuration file from disk on every request. This ensures that changes to `ignored_players` in `dashboard-config.json` take effect immediately without requiring a server restart.
2.  **Anti-Caching Headers**: Added aggressive `Cache-Control: no-cache` headers to the `HtmlHandler`, `ApiHandler`, and `PlayerMetaHandler` in `DashboardWebServer`. This forces the browser to fetch fresh content and data on every page load.
3.  **Documentation Update**: Updated `GEMINI.md` with guidelines on resource versioning and cache management for future development.

### Impact
Users will no longer see ignored players once they are added to the config, and the dashboard will always reflect the most up-to-date activity data without requiring manual browser cache clears.