### PR TITLE
feat: integrate dynmap and refine dashboard UI

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -19,7 +19,7 @@ public class DashboardConfig {
     public int web_port = 8105;
     public int incremental_update_interval_minutes = 5;
     public String logs_directory = ""; // Leave empty to use default (game_dir/logs)
-    public String dashboard_title = "Player Session Activity";
+    public String dashboard_title = "Activity Dashboard";
     public String dashboard_description = "Combined playtime from join/leave events";
     public String tab_title = "Playtime Dashboard";
     public String server_name = "MC Server";
@@ -31,6 +31,8 @@ public class DashboardConfig {
     public int skin_refresh_hours = 24;            // Hours before re-fetching a player's skin
     public String stats_world_name = "world"; // Minecraft world folder name
     public int leaderboard_update_interval_minutes = 10; // Can differ from incremental_update_interval_minutes
+    public boolean enable_dynmap = true;
+    public String dynmap_url = "http://149.56.155.7:8032";
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static DashboardConfig instance;
@@ -44,6 +46,7 @@ public class DashboardConfig {
 
     public static void load() {
         File configFile = new File(FabricLoader.getInstance().getConfigDir().toFile(), "dashboard-config.json");
+        boolean newlyCreated = false;
         if (configFile.exists()) {
             try (FileReader reader = new FileReader(configFile)) {
                 instance = GSON.fromJson(reader, DashboardConfig.class);
@@ -54,9 +57,13 @@ public class DashboardConfig {
         
         if (instance == null) {
             instance = new DashboardConfig();
+            newlyCreated = true;
         }
-        // Always save to ensure new default fields are written back to the file
-        save();
+        
+        // Only save if it's a brand new config to avoid overwriting user edits
+        if (newlyCreated) {
+            save();
+        }
     }
 
     public static void save() {

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -309,6 +309,10 @@ public class DashboardWebServer {
                 html = html.replace("{{SERVER_NAME}}", config.server_name != null ? config.server_name : "MC Server");
                 html = html.replace("{{DASHBOARD_TITLE}}", config.dashboard_title != null ? config.dashboard_title : "Player Activity");
                 html = html.replace("{{DASHBOARD_DESCRIPTION}}", config.dashboard_description != null ? config.dashboard_description : "Session data");
+                html = html.replace("{{ENABLE_DYNMAP}}", String.valueOf(config.enable_dynmap));
+                html = html.replace("{{DYNMAP_URL}}", config.dynmap_url != null ? config.dynmap_url : "");
+                
+                FabricDashboardMod.LOGGER.info("Serving dashboard. Dynmap enabled: " + config.enable_dynmap + ", URL: " + config.dynmap_url);
                 
                 byte[] response = html.getBytes(StandardCharsets.UTF_8);
                 exchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -419,7 +419,6 @@
         </div>
         <div>
           <h1 class="page-title">{{DASHBOARD_TITLE}}</h1>
-          <p class="page-sub" id="pageSub">{{DASHBOARD_DESCRIPTION}}</p>
         </div>
       </div>
     </header>
@@ -428,9 +427,11 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
 
       <div id="viewPlaytime" style="display:flex;flex-direction:column;gap:var(--space-6);">
+        <p class="page-sub" id="pageSub" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
         <div class="kpi-row" id="kpiRow"></div>
 
         <div class="card" style="height:fit-content;">
@@ -563,6 +564,10 @@
         </div>
       </div>
 
+      <div id="viewDynmap" style="display:none; width:100%; height:85dvh; border-radius:var(--radius-xl); border:1px solid var(--color-border); background:var(--color-surface); overflow:hidden; box-shadow:var(--shadow-lg);">
+        <iframe id="dynmapFrame" src="" style="width:100%; height:100%; border:none;" allowfullscreen></iframe>
+      </div>
+
       <div class="modal-overlay" id="playerModal">
         <div class="modal-content">
           <button class="modal-close" onclick="closePlayerModal()">✕</button>
@@ -605,6 +610,9 @@
 
     <script>
       console.log("[Playtime] Script starting...");
+      const ENABLE_DYNMAP = "{{ENABLE_DYNMAP}}" === "true";
+      const DYNMAP_URL = "{{DYNMAP_URL}}";
+      console.log("[Playtime] Dynmap Config:", { ENABLE_DYNMAP, DYNMAP_URL });
       const statusEl = document.getElementById('loadingStatus');
       const crashEl = document.getElementById('crashMessage');
       const overlayEl = document.getElementById('loadingOverlay');
@@ -1429,8 +1437,40 @@
         }
       }
 
-      document.getElementById('tabPlaytime').addEventListener('click', () => { document.getElementById('tabPlaytime').classList.add('active'); document.getElementById('tabLeaderboards').classList.remove('active'); document.getElementById('viewPlaytime').style.display = 'flex'; document.getElementById('viewLeaderboards').style.display = 'none'; });
-      document.getElementById('tabLeaderboards').addEventListener('click', () => { document.getElementById('tabLeaderboards').classList.add('active'); document.getElementById('tabPlaytime').classList.remove('active'); document.getElementById('viewLeaderboards').style.display = 'flex'; document.getElementById('viewPlaytime').style.display = 'none'; if (!leaderboardsData) loadLeaderboards(); });
+      const updateTabs = (activeId) => {
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewDynmap'];
+        tabs.forEach((id, i) => {
+          const btn = document.getElementById(id);
+          const view = document.getElementById(views[i]);
+          if (id === activeId) {
+            btn.classList.add('active');
+            view.style.display = (id === 'viewDynmap' || id === 'tabDynmap') ? 'block' : 'flex';
+          } else {
+            btn.classList.remove('active');
+            view.style.display = 'none';
+          }
+        });
+      };
+
+      document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
+      document.getElementById('tabLeaderboards').addEventListener('click', () => { 
+        updateTabs('tabLeaderboards'); 
+        if (!leaderboardsData) loadLeaderboards(); 
+      });
+      document.getElementById('tabDynmap').addEventListener('click', () => {
+        console.log("[Playtime] Switching to Dynmap tab...");
+        updateTabs('tabDynmap');
+        const frame = document.getElementById('dynmapFrame');
+        if (!frame.src || frame.src === "about:blank" || frame.src === window.location.href) {
+          console.log("[Playtime] Loading Dynmap iframe with URL:", DYNMAP_URL);
+          frame.src = DYNMAP_URL;
+        }
+      });
+
+      if (ENABLE_DYNMAP) {
+        document.getElementById('tabDynmap').style.display = 'block';
+      }
       document.getElementById('btnPie').addEventListener('click', () => { 
         currentViewMode = 'pie'; 
         document.getElementById('btnPie').style.background = 'var(--color-primary)'; 

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -419,7 +419,6 @@
         </div>
         <div>
           <h1 class="page-title">{{DASHBOARD_TITLE}}</h1>
-          <p class="page-sub" id="pageSub">{{DASHBOARD_DESCRIPTION}}</p>
         </div>
       </div>
     </header>
@@ -428,9 +427,11 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
 
       <div id="viewPlaytime" style="display:flex;flex-direction:column;gap:var(--space-6);">
+        <p class="page-sub" id="pageSub" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
         <div class="kpi-row" id="kpiRow"></div>
 
         <div class="card" style="height:fit-content;">
@@ -563,6 +564,10 @@
         </div>
       </div>
 
+      <div id="viewDynmap" style="display:none; width:100%; height:85dvh; border-radius:var(--radius-xl); border:1px solid var(--color-border); background:var(--color-surface); overflow:hidden; box-shadow:var(--shadow-lg);">
+        <iframe id="dynmapFrame" src="" style="width:100%; height:100%; border:none;" allowfullscreen></iframe>
+      </div>
+
       <div class="modal-overlay" id="playerModal">
         <div class="modal-content">
           <button class="modal-close" onclick="closePlayerModal()">✕</button>
@@ -605,6 +610,9 @@
 
     <script>
       console.log("[Playtime] Script starting...");
+      const ENABLE_DYNMAP = "{{ENABLE_DYNMAP}}" === "true";
+      const DYNMAP_URL = "{{DYNMAP_URL}}";
+      console.log("[Playtime] Dynmap Config:", { ENABLE_DYNMAP, DYNMAP_URL });
       const statusEl = document.getElementById('loadingStatus');
       const crashEl = document.getElementById('crashMessage');
       const overlayEl = document.getElementById('loadingOverlay');
@@ -1429,8 +1437,40 @@
         }
       }
 
-      document.getElementById('tabPlaytime').addEventListener('click', () => { document.getElementById('tabPlaytime').classList.add('active'); document.getElementById('tabLeaderboards').classList.remove('active'); document.getElementById('viewPlaytime').style.display = 'flex'; document.getElementById('viewLeaderboards').style.display = 'none'; });
-      document.getElementById('tabLeaderboards').addEventListener('click', () => { document.getElementById('tabLeaderboards').classList.add('active'); document.getElementById('tabPlaytime').classList.remove('active'); document.getElementById('viewLeaderboards').style.display = 'flex'; document.getElementById('viewPlaytime').style.display = 'none'; if (!leaderboardsData) loadLeaderboards(); });
+      const updateTabs = (activeId) => {
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewDynmap'];
+        tabs.forEach((id, i) => {
+          const btn = document.getElementById(id);
+          const view = document.getElementById(views[i]);
+          if (id === activeId) {
+            btn.classList.add('active');
+            view.style.display = (id === 'viewDynmap' || id === 'tabDynmap') ? 'block' : 'flex';
+          } else {
+            btn.classList.remove('active');
+            view.style.display = 'none';
+          }
+        });
+      };
+
+      document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
+      document.getElementById('tabLeaderboards').addEventListener('click', () => { 
+        updateTabs('tabLeaderboards'); 
+        if (!leaderboardsData) loadLeaderboards(); 
+      });
+      document.getElementById('tabDynmap').addEventListener('click', () => {
+        console.log("[Playtime] Switching to Dynmap tab...");
+        updateTabs('tabDynmap');
+        const frame = document.getElementById('dynmapFrame');
+        if (!frame.src || frame.src === "about:blank" || frame.src === window.location.href) {
+          console.log("[Playtime] Loading Dynmap iframe with URL:", DYNMAP_URL);
+          frame.src = DYNMAP_URL;
+        }
+      });
+
+      if (ENABLE_DYNMAP) {
+        document.getElementById('tabDynmap').style.display = 'block';
+      }
       document.getElementById('btnPie').addEventListener('click', () => { 
         currentViewMode = 'pie'; 
         document.getElementById('btnPie').style.background = 'var(--color-primary)'; 


### PR DESCRIPTION
This PR integrates Dynmap into the Minecraft Activity Dashboard.

### Features:
- **Dynmap Tab**: A new tab in the dashboard that embeds the Dynmap interface using an iframe.
- **Configurable**: Added `enable_dynmap` and `dynmap_url` to `dashboard-config.json`.
- **State Preservation**: The map state is preserved when switching between dashboard tabs.
- **Diagnostic Logging**: Added frontend and backend logs to troubleshoot connectivity or CORS issues.
- **Layout Improvements**: Moved the dashboard description to the Playtime tab for a cleaner header and updated the default title to "Activity Dashboard".
- **Bug Fix**: Prevented the mod from overwriting manual config edits on startup.

Closes #[ISSUE_NUMBER_IF_ANY]