### PR TITLE
feat: add block activity stats and modal UI improvements

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
+++ b/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
@@ -12,12 +12,39 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public class StatsAggregator {
+    private static final Set<String> ITEM_SUFFIXES = new HashSet<>(Arrays.asList(
+        "_sword", "_pickaxe", "_axe", "_shovel", "_hoe", "_helmet", "_chestplate", "_leggings", "_boots",
+        "_bucket", "_potion", "_stew", "_soup", "_bottle", "_pearl", "_egg", "_rod", "_shears", "_bow",
+        "_crossbow", "_trident", "_shield", "_rod", "_flint_and_steel", "_spyglass", "_compass", "_clock"
+    ));
+    
+    private static final Set<String> ITEM_NAMES = new HashSet<>(Arrays.asList(
+        "minecraft:apple", "minecraft:bread", "minecraft:steak", "minecraft:cooked_porkchop", "minecraft:cooked_mutton",
+        "minecraft:cooked_chicken", "minecraft:cooked_rabbit", "minecraft:cooked_cod", "minecraft:cooked_salmon",
+        "minecraft:cookie", "minecraft:pumpkin_pie", "minecraft:sweet_berries", "minecraft:glow_berries",
+        "minecraft:melon_slice", "minecraft:carrot", "minecraft:potato", "minecraft:baked_potato", "minecraft:poisonous_potato",
+        "minecraft:dried_kelp", "minecraft:honey_bottle", "minecraft:totem_of_undying", "minecraft:experience_bottle",
+        "minecraft:ender_pearl", "minecraft:snowball", "minecraft:egg", "minecraft:firework_rocket", "minecraft:firework_star",
+        "minecraft:lead", "minecraft:name_tag", "minecraft:bone_meal", "minecraft:ender_eye", "minecraft:ghast_tear"
+    ));
+
+    private boolean isBlockPlacement(String statId) {
+        if (ITEM_NAMES.contains(statId)) return false;
+        for (String suffix : ITEM_SUFFIXES) {
+            if (statId.endsWith(suffix)) return false;
+        }
+        return true;
+    }
+
     public Map<String, Map<String, Map<String, Integer>>> buildLeaderboards(Path statsDir, UuidCache uuidCache) {
         // Map<Category, Map<Stat, Map<PlayerName, Value>>>
         Map<String, Map<String, Map<String, Integer>>> result = new LinkedHashMap<>();
@@ -81,6 +108,8 @@ public class StatsAggregator {
         long distanceCm = 0;
         int damageTaken = 0;
         int damageDealt = 0;
+        int totalMined = 0;
+        int totalUsed = 0;
 
         Map<String, Map<String, Integer>> filteredCategory = result.computeIfAbsent("general", k -> new LinkedHashMap<>());
 
@@ -94,6 +123,12 @@ public class StatsAggregator {
                     while (reader.hasNext()) {
                         String stat = reader.nextName();
                         int value = reader.nextInt();
+
+                        if ("minecraft:mined".equals(category)) {
+                            totalMined += value;
+                        } else if ("minecraft:used".equals(category) && isBlockPlacement(stat)) {
+                            totalUsed += value;
+                        }
 
                         if (stat.endsWith("_one_cm")) {
                             distanceCm += value;
@@ -141,6 +176,14 @@ public class StatsAggregator {
         if (damageDealt > 0) {
             filteredCategory.computeIfAbsent("damage_dealt_hearts", k -> new LinkedHashMap<>())
                     .merge(playerName, damageDealt / 10, Integer::sum);
+        }
+        if (totalMined > 0) {
+            filteredCategory.computeIfAbsent("total_blocks_broken", k -> new LinkedHashMap<>())
+                    .merge(playerName, totalMined, Integer::sum);
+        }
+        if (totalUsed > 0) {
+            filteredCategory.computeIfAbsent("total_blocks_placed", k -> new LinkedHashMap<>())
+                    .merge(playerName, totalUsed, Integer::sum);
         }
     }
 

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -667,6 +667,8 @@
       const rankClass = ['rank-1', 'rank-2', 'rank-3'];
       const STAT_CONFIG = [
         { id: 'distance_traveled_km', name: 'Total Distance Traveled', label: 'Distance Traveled', suffix: ' km' },
+        { id: 'total_blocks_broken', name: 'Total Blocks Broken', label: 'Blocks Broken', suffix: '' },
+        { id: 'total_blocks_placed', name: 'Total Blocks Placed', label: 'Blocks Placed', suffix: '' },
         { id: 'player_kills', name: 'Players Killed', label: 'Players Killed', suffix: '' },
         { id: 'mob_kills', name: 'Mobs Killed', label: 'Mobs Killed', suffix: '' },
         { id: 'deaths', name: 'Total Deaths', label: 'Total Deaths', suffix: '' },
@@ -1304,8 +1306,16 @@
           if (!res.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
           const data = await res.json(); if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
           let distCm = 0; let extracted = {};
+          let totalMined = 0;
+          let totalUsed = 0;
+          const ITEM_SUFFIXES = ['_sword', '_pickaxe', '_axe', '_shovel', '_hoe', '_helmet', '_chestplate', '_leggings', '_boots', '_bucket', '_potion', '_stew', '_soup', '_bottle', '_pearl', '_egg', '_rod', '_shears', '_bow', '_crossbow', '_trident', '_shield', '_flint_and_steel', '_spyglass', '_compass', '_clock'];
+          const ITEM_NAMES = ['minecraft:apple', 'minecraft:bread', 'minecraft:steak', 'minecraft:cooked_porkchop', 'minecraft:cooked_mutton', 'minecraft:cooked_chicken', 'minecraft:cooked_rabbit', 'minecraft:cooked_cod', 'minecraft:cooked_salmon', 'minecraft:cookie', 'minecraft:pumpkin_pie', 'minecraft:sweet_berries', 'minecraft:glow_berries', 'minecraft:melon_slice', 'minecraft:carrot', 'minecraft:potato', 'minecraft:baked_potato', 'minecraft:poisonous_potato', 'minecraft:dried_kelp', 'minecraft:honey_bottle', 'minecraft:totem_of_undying', 'minecraft:experience_bottle', 'minecraft:ender_pearl', 'minecraft:snowball', 'minecraft:egg', 'minecraft:firework_rocket', 'minecraft:firework_star', 'minecraft:lead', 'minecraft:name_tag', 'minecraft:bone_meal', 'minecraft:ender_eye', 'minecraft:ghast_tear'];
+          const isBlockPlacement = (s) => !ITEM_NAMES.includes(s) && !ITEM_SUFFIXES.some(sx => s.endsWith(sx));
+
           for (const [cat, stats] of Object.entries(data.stats)) {
             for (const [sN, sV] of Object.entries(stats)) {
+              if (cat === 'minecraft:mined') totalMined += sV;
+              if (cat === 'minecraft:used' && isBlockPlacement(sN)) totalUsed += sV;
               if (sN.endsWith('_one_cm')) distCm += sV;
               else if (sN === 'minecraft:damage_taken') extracted['damage_taken_hearts'] = Math.floor(sV / 10);
               else if (sN === 'minecraft:damage_dealt') extracted['damage_dealt_hearts'] = Math.floor(sV / 10);
@@ -1320,9 +1330,14 @@
               else if (sN === 'minecraft:ender_dragon') extracted['ender_dragon'] = sV;
             }
           }
+          if (totalMined > 0) extracted['total_blocks_broken'] = totalMined;
+          if (totalUsed > 0) extracted['total_blocks_placed'] = totalUsed;
           if (distCm > 0) extracted['distance_traveled_km'] = Math.floor(distCm / 100000);
-          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { const v = extracted[s.id]; return (v !== undefined && v > 0) ? `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>` : ''; }).join('') + `</div>`;
-          container.innerHTML = Object.keys(extracted).length ? h : '<div style="text-align:center;color:var(--color-text-faint);">No relevant stats.</div>';
+          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { 
+            const v = extracted[s.id] || 0; 
+            return `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>`; 
+          }).join('') + `</div>`;
+          container.innerHTML = h;
         } catch (e) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error.</div>'; }
       }
 

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -667,6 +667,8 @@
       const rankClass = ['rank-1', 'rank-2', 'rank-3'];
       const STAT_CONFIG = [
         { id: 'distance_traveled_km', name: 'Total Distance Traveled', label: 'Distance Traveled', suffix: ' km' },
+        { id: 'total_blocks_broken', name: 'Total Blocks Broken', label: 'Blocks Broken', suffix: '' },
+        { id: 'total_blocks_placed', name: 'Total Blocks Placed', label: 'Blocks Placed', suffix: '' },
         { id: 'player_kills', name: 'Players Killed', label: 'Players Killed', suffix: '' },
         { id: 'mob_kills', name: 'Mobs Killed', label: 'Mobs Killed', suffix: '' },
         { id: 'deaths', name: 'Total Deaths', label: 'Total Deaths', suffix: '' },
@@ -1304,8 +1306,16 @@
           if (!res.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
           const data = await res.json(); if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
           let distCm = 0; let extracted = {};
+          let totalMined = 0;
+          let totalUsed = 0;
+          const ITEM_SUFFIXES = ['_sword', '_pickaxe', '_axe', '_shovel', '_hoe', '_helmet', '_chestplate', '_leggings', '_boots', '_bucket', '_potion', '_stew', '_soup', '_bottle', '_pearl', '_egg', '_rod', '_shears', '_bow', '_crossbow', '_trident', '_shield', '_flint_and_steel', '_spyglass', '_compass', '_clock'];
+          const ITEM_NAMES = ['minecraft:apple', 'minecraft:bread', 'minecraft:steak', 'minecraft:cooked_porkchop', 'minecraft:cooked_mutton', 'minecraft:cooked_chicken', 'minecraft:cooked_rabbit', 'minecraft:cooked_cod', 'minecraft:cooked_salmon', 'minecraft:cookie', 'minecraft:pumpkin_pie', 'minecraft:sweet_berries', 'minecraft:glow_berries', 'minecraft:melon_slice', 'minecraft:carrot', 'minecraft:potato', 'minecraft:baked_potato', 'minecraft:poisonous_potato', 'minecraft:dried_kelp', 'minecraft:honey_bottle', 'minecraft:totem_of_undying', 'minecraft:experience_bottle', 'minecraft:ender_pearl', 'minecraft:snowball', 'minecraft:egg', 'minecraft:firework_rocket', 'minecraft:firework_star', 'minecraft:lead', 'minecraft:name_tag', 'minecraft:bone_meal', 'minecraft:ender_eye', 'minecraft:ghast_tear'];
+          const isBlockPlacement = (s) => !ITEM_NAMES.includes(s) && !ITEM_SUFFIXES.some(sx => s.endsWith(sx));
+
           for (const [cat, stats] of Object.entries(data.stats)) {
             for (const [sN, sV] of Object.entries(stats)) {
+              if (cat === 'minecraft:mined') totalMined += sV;
+              if (cat === 'minecraft:used' && isBlockPlacement(sN)) totalUsed += sV;
               if (sN.endsWith('_one_cm')) distCm += sV;
               else if (sN === 'minecraft:damage_taken') extracted['damage_taken_hearts'] = Math.floor(sV / 10);
               else if (sN === 'minecraft:damage_dealt') extracted['damage_dealt_hearts'] = Math.floor(sV / 10);
@@ -1320,9 +1330,14 @@
               else if (sN === 'minecraft:ender_dragon') extracted['ender_dragon'] = sV;
             }
           }
+          if (totalMined > 0) extracted['total_blocks_broken'] = totalMined;
+          if (totalUsed > 0) extracted['total_blocks_placed'] = totalUsed;
           if (distCm > 0) extracted['distance_traveled_km'] = Math.floor(distCm / 100000);
-          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { const v = extracted[s.id]; return (v !== undefined && v > 0) ? `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>` : ''; }).join('') + `</div>`;
-          container.innerHTML = Object.keys(extracted).length ? h : '<div style="text-align:center;color:var(--color-text-faint);">No relevant stats.</div>';
+          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { 
+            const v = extracted[s.id] || 0; 
+            return `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>`; 
+          }).join('') + `</div>`;
+          container.innerHTML = h;
         } catch (e) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error.</div>'; }
       }
 


### PR DESCRIPTION
### Features
- Added "Total Blocks Broken" leaderboard and player stat card.
- Added "Total Blocks Placed" leaderboard and player stat card (filtered to exclude non-block item usage).
- Updated player profile modal to show all tracked stats, even if the value is zero.

### Technical Details
- Implemented `isBlockPlacement` helper in `StatsAggregator.java` and frontend to distinguish block placement from item usage in the `minecraft:used` category.
- Updated `fetchPlayerStats` to ensure all stats defined in `STAT_CONFIG` are displayed in the modal grid.
- Synchronized frontend assets to backend resources.