### PR TITLE
fix: player stats lookup and diagnostic logging

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/util/UuidCache.java
+++ b/backend/src/main/java/com/playtime/dashboard/util/UuidCache.java
@@ -58,7 +58,41 @@ public class UuidCache {
     }
 
     public Optional<UUID> getUuid(String username) {
-        return Optional.ofNullable(nameToUuid.get(username.toLowerCase()));
+        UUID uuid = nameToUuid.get(username.toLowerCase());
+        if (uuid != null) return Optional.of(uuid);
+
+        // Try Mojang API for Name -> UUID
+        FabricDashboardMod.LOGGER.info("UUID for '" + username + "' not found locally, trying Mojang API...");
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.mojang.com/users/profiles/minecraft/" + username))
+                    .GET()
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                JsonObject json = com.google.gson.JsonParser.parseString(response.body()).getAsJsonObject();
+                if (json.has("id")) {
+                    String id = json.get("id").getAsString();
+                    // Mojang returns undashed UUIDs
+                    if (id.length() == 32) {
+                        id = id.substring(0, 8) + "-" + id.substring(8, 12) + "-" + id.substring(12, 16) + "-" + id.substring(16, 20) + "-" + id.substring(20);
+                    }
+                    UUID resolvedUuid = UUID.fromString(id);
+                    FabricDashboardMod.LOGGER.info("Successfully resolved '" + username + "' to " + resolvedUuid + " via Mojang");
+                    // Add to our transient cache so we don't spam Mojang
+                    uuidToName.put(resolvedUuid, username);
+                    nameToUuid.put(username.toLowerCase(), resolvedUuid);
+                    return Optional.of(resolvedUuid);
+                }
+            } else {
+                FabricDashboardMod.LOGGER.warn("Mojang API returned status " + response.statusCode() + " for '" + username + "'");
+            }
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Mojang API lookup failed for '" + username + "': " + e.getMessage());
+        }
+
+        return Optional.empty();
     }
 
     public Optional<String> getUsername(UUID uuid) {

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerStatsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerStatsHandler.java
@@ -38,6 +38,7 @@ public class PlayerStatsHandler implements HttpHandler {
         }
 
         String username = path.substring(prefix.length());
+        FabricDashboardMod.LOGGER.info("PlayerStatsHandler: Request for '" + username + "'");
         
         if (!username.matches("[\\w/\\-]+")) {
             sendError(exchange, 400, "Invalid username format");
@@ -75,11 +76,13 @@ public class PlayerStatsHandler implements HttpHandler {
 
         try {
             statsAggregator.streamPlayerStats(username, uuidCache, baseStatsDir, lazyOut);
+            FabricDashboardMod.LOGGER.info("PlayerStatsHandler: Successfully served stats for '" + username + "'");
             lazyOut.close();
         } catch (FileNotFoundException e) {
+            FabricDashboardMod.LOGGER.warn("PlayerStatsHandler: Stats not found for '" + username + "': " + e.getMessage());
             sendError(exchange, 404, "Player not found");
         } catch (Exception e) {
-            FabricDashboardMod.LOGGER.error("Failed to serve player stats", e);
+            FabricDashboardMod.LOGGER.error("PlayerStatsHandler: Error serving stats for '" + username + "'", e);
             sendError(exchange, 500, "Internal Server Error");
         }
     }


### PR DESCRIPTION
### Fixes
- Resolved issue where individual player stats would fail to load in the modal if the player was missing from the local `usercache.json`.
- Implemented a fallback Mojang API lookup in `UuidCache.java` to resolve usernames to UUIDs on-demand.

### Diagnostics
- Added detailed logging to `PlayerStatsHandler.java` and `UuidCache.java` to track incoming requests, name-to-UUID resolution, and any potential lookup failures.

### Technical Details
- Added `getUuid(String username)` Mojang API integration.
- Standardized logging prefixes for easier log filtering (`PlayerStatsHandler: ...`).