### PR TITLE
feat: add live server metrics tab and real-time monitoring

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -33,6 +33,8 @@ public class DashboardConfig {
     public int leaderboard_update_interval_minutes = 10; // Can differ from incremental_update_interval_minutes
     public boolean enable_dynmap = true;
     public String dynmap_url = "http://149.56.155.7:8032";
+    public boolean enable_live_tab = true;
+    public int live_update_interval_seconds = 3;
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static DashboardConfig instance;

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -10,6 +10,8 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import net.minecraft.server.MinecraftServer;
 import net.fabricmc.loader.api.FabricLoader;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -34,13 +36,58 @@ import java.util.concurrent.TimeUnit;
 public class DashboardWebServer {
     private final MinecraftServer minecraftServer;
     private HttpServer httpServer;
-    private ScheduledExecutorService scheduler;
     private final LogParser parser;
     private final File cacheFile;
     private final PlayerHeadService headService;
     private final File leaderboardCacheFile;
     private final StatsAggregator statsAggregator;
     private final UuidCache uuidCache;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+    private volatile LiveMetricsSnapshot liveSnapshot;
+    private long cachedWorldSizeMb = 0;
+    private long lastWorldSizeCheck = 0;
+
+    public static class LiveMetricsSnapshot {
+        public final int playersOnline;
+        public final int maxPlayers;
+        public final List<String> playerNames;
+        public final double tps;
+        public final double mspt;
+        public final double cpuProcess;
+        public final long jvmUsedMb;
+        public final long jvmMaxMb;
+        public final double diskUsedGb;
+        public final double diskTotalGb;
+        public final double diskFreeGb;
+        public final long worldSizeMb;
+        public final String status;
+        public final long timestamp;
+
+        public LiveMetricsSnapshot(int playersOnline, int maxPlayers, List<String> playerNames, 
+                                   double tps, double mspt, double cpuProcess, 
+                                   long jvmUsedMb, long jvmMaxMb, double diskUsedGb, 
+                                   double diskTotalGb, double diskFreeGb, long worldSizeMb, String status) {
+            this.playersOnline = playersOnline;
+            this.maxPlayers = maxPlayers;
+            this.playerNames = Collections.unmodifiableList(playerNames);
+            this.tps = tps;
+            this.mspt = mspt;
+            this.cpuProcess = cpuProcess;
+            this.jvmUsedMb = jvmUsedMb;
+            this.jvmMaxMb = jvmMaxMb;
+            this.diskUsedGb = diskUsedGb;
+            this.diskTotalGb = diskTotalGb;
+            this.diskFreeGb = diskFreeGb;
+            this.worldSizeMb = worldSizeMb;
+            this.status = status;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        // Warming up constructor
+        public LiveMetricsSnapshot() {
+            this(0, 0, new ArrayList<>(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "warming_up");
+        }
+    }
 
     public DashboardWebServer(MinecraftServer server) {
         this.minecraftServer = server;
@@ -64,13 +111,13 @@ public class DashboardWebServer {
             httpServer.createContext("/skins/", new SkinHandler(headService));
             httpServer.createContext("/api/leaderboards", new LeaderboardHandler(leaderboardCacheFile));
             httpServer.createContext("/api/player-stats/", new PlayerStatsHandler(statsAggregator, uuidCache));
+            httpServer.createContext("/api/live", new LiveMetricsHandler(this));
             
             httpServer.setExecutor(Executors.newFixedThreadPool(2));
             httpServer.start();
             FabricDashboardMod.LOGGER.info("Dashboard Web Server started on port " + port);
 
             // Setup scheduling
-            scheduler = Executors.newScheduledThreadPool(2);
             
             // Run historical parse once if needed, then schedule incremental
             scheduler.execute(() -> {
@@ -125,11 +172,90 @@ public class DashboardWebServer {
                     }
                     parser.runIncrementalParse(incLogsDir, cacheFile);
                 }, delay, delay, TimeUnit.MINUTES);
+
+                // Live metrics sampling
+                if (DashboardConfig.get().enable_live_tab) {
+                    liveSnapshot = new LiveMetricsSnapshot();
+                    long liveInterval = DashboardConfig.get().live_update_interval_seconds;
+                    scheduler.scheduleAtFixedRate(this::updateLiveMetrics, 0, liveInterval, TimeUnit.SECONDS);
+                }
             });
 
         } catch (IOException e) {
             FabricDashboardMod.LOGGER.error("Failed to start Dashboard Web Server", e);
         }
+    }
+
+    private void updateLiveMetrics() {
+        try {
+            // Player data
+            int playersOnline = minecraftServer.getPlayerManager().getCurrentPlayerCount();
+            int maxPlayers = minecraftServer.getPlayerManager().getMaxPlayerCount();
+            List<String> playerNames = new ArrayList<>();
+            minecraftServer.getPlayerManager().getPlayerList().forEach(player -> {
+                if (playerNames.size() < 100) {
+                    playerNames.add(player.getGameProfile().getName());
+                }
+            });
+
+            // TPS / MSPT
+            double tps = 0;
+            double mspt = 0;
+            long[] tickTimes = minecraftServer.getTickTimes(); // Internal reference, used transiently
+            if (tickTimes != null && tickTimes.length > 0) {
+                long sum = 0;
+                for (long time : tickTimes) sum += time;
+                mspt = (sum / (double) tickTimes.length) * 1.0E-6D;
+                tps = Math.min(20.0D, 1000.0D / mspt);
+            }
+
+            // CPU / Memory
+            double cpuProcess = 0;
+            OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+            if (osBean instanceof com.sun.management.OperatingSystemMXBean) {
+                com.sun.management.OperatingSystemMXBean sunBean = (com.sun.management.OperatingSystemMXBean) osBean;
+                cpuProcess = sunBean.getProcessCpuLoad() * 100.0;
+            }
+            
+            Runtime runtime = Runtime.getRuntime();
+            long jvmMaxMb = runtime.maxMemory() / (1024 * 1024);
+            long jvmUsedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024);
+
+            // Disk Usage
+            File targetDir = new File("/home/container");
+            if (!targetDir.exists()) {
+                targetDir = FabricLoader.getInstance().getGameDir().toFile();
+            }
+            
+            double diskTotalGb = targetDir.getTotalSpace() / (1024.0 * 1024.0 * 1024.0);
+            double diskFreeGb = targetDir.getUsableSpace() / (1024.0 * 1024.0 * 1024.0);
+            double diskUsedGb = diskTotalGb - diskFreeGb;
+
+            // World Size (Expensive, update every 10 minutes)
+            if (System.currentTimeMillis() - lastWorldSizeCheck > 600000) {
+                cachedWorldSizeMb = calculateDirectorySize(targetDir) / (1024 * 1024);
+                lastWorldSizeCheck = System.currentTimeMillis();
+            }
+
+            this.liveSnapshot = new LiveMetricsSnapshot(playersOnline, maxPlayers, playerNames, 
+                                                        tps, mspt, cpuProcess, 
+                                                        jvmUsedMb, jvmMaxMb, diskUsedGb, 
+                                                        diskTotalGb, diskFreeGb, cachedWorldSizeMb, "ok");
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Failed to update live metrics", e);
+        }
+    }
+
+    private long calculateDirectorySize(File directory) {
+        long length = 0;
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isFile()) length += file.length();
+                else length += calculateDirectorySize(file);
+            }
+        }
+        return length;
     }
 
     /** Scans the cache file for all known player names and kicks off head fetches. */
@@ -311,6 +437,9 @@ public class DashboardWebServer {
                 html = html.replace("{{DASHBOARD_DESCRIPTION}}", config.dashboard_description != null ? config.dashboard_description : "Session data");
                 html = html.replace("{{ENABLE_DYNMAP}}", String.valueOf(config.enable_dynmap));
                 html = html.replace("{{DYNMAP_URL}}", config.dynmap_url != null ? config.dynmap_url : "");
+                html = html.replace("{{ENABLE_LIVE_TAB}}", String.valueOf(config.enable_live_tab));
+                html = html.replace("{{LIVE_UPDATE_INTERVAL_MS}}", String.valueOf(config.live_update_interval_seconds * 1000));
+                html = html.replace("{{LIVE_TAB_DISPLAY}}", config.enable_live_tab ? "block" : "none");
                 
                 FabricDashboardMod.LOGGER.info("Serving dashboard. Dynmap enabled: " + config.enable_dynmap + ", URL: " + config.dynmap_url);
                 
@@ -581,6 +710,39 @@ public class DashboardWebServer {
             } catch (Exception e) {
                 FabricDashboardMod.LOGGER.error("Failed to serve filtered API activity", e);
                 exchange.sendResponseHeaders(500, -1);
+            }
+        }
+    }
+
+    private static class LiveMetricsHandler implements HttpHandler {
+        private final DashboardWebServer server;
+        private static final Gson GSON = new Gson();
+
+        public LiveMetricsHandler(DashboardWebServer server) {
+            this.server = server;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+
+            LiveMetricsSnapshot snapshot = server.liveSnapshot;
+            if (snapshot == null) {
+                snapshot = new LiveMetricsSnapshot(); // warming_up state
+            }
+
+            byte[] response = GSON.toJson(snapshot).getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+            exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+            exchange.getResponseHeaders().set("Pragma", "no-cache");
+            exchange.getResponseHeaders().set("Expires", "0");
+            exchange.sendResponseHeaders(200, response.length);
+            
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
             }
         }
     }

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -250,6 +250,26 @@
         border-color: var(--color-primary);
         box-shadow: 0 0 0 2px var(--color-primary-highlight);
       }
+      
+      .live-player-card {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-2) var(--space-4);
+        border-radius: var(--radius-lg);
+        background: var(--color-surface-dynamic);
+        border: 1px solid var(--color-border);
+        cursor: pointer;
+        transition: all var(--transition);
+        font-weight: 600;
+        font-size: var(--text-sm);
+      }
+      .live-player-card:hover {
+        background: var(--color-surface-offset);
+        border-color: var(--color-text-faint);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-md);
+      }
       .select-options {
         position: absolute;
         top: calc(100% + 8px);
@@ -427,6 +447,7 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabLive" class="tab-btn" style="display:{{LIVE_TAB_DISPLAY}};">Live</button>
         <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
 
@@ -525,6 +546,7 @@
       </div> <!-- end viewPlaytime -->
 
       <div id="viewLeaderboards" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" id="pageSubLeaderboards" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
         <div class="card">
           <div style="display:flex; gap:var(--space-4); margin-bottom: var(--space-6);">
             <div class="custom-select" id="statSelectContainer" style="flex:1; margin-bottom: 0;">
@@ -560,6 +582,49 @@
                 <!-- Data dynamic -->
               </tbody>
             </table>
+          </div>
+        </div>
+      </div>
+      
+      <div id="viewLive" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" id="liveLastUpdate" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">Last update: never</p>
+        <div class="kpi-row" id="liveKpiRow">
+          <div class="kpi">
+            <div class="kpi-label">Players Online</div>
+            <div class="kpi-value" id="livePlayersValue">0 / 0</div>
+            <div class="kpi-note" id="livePlayersNote">Waiting for data...</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Server TPS</div>
+            <div class="kpi-value" id="liveTpsValue">0.0</div>
+            <div class="kpi-note" id="liveTpsNote">Target 20.0</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Avg MSPT</div>
+            <div class="kpi-value" id="liveMsptValue">0.0 ms</div>
+            <div class="kpi-note" id="liveMsptNote">Target &lt; 50ms</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">CPU Usage</div>
+            <div class="kpi-value" id="liveCpuValue">0%</div>
+            <div class="kpi-note" id="liveCpuNote">Process Load</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Memory Usage</div>
+            <div class="kpi-value" id="liveMemValue">0 / 0 MB</div>
+            <div class="kpi-note" id="liveMemNote">JVM Heap</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Disk Space</div>
+            <div class="kpi-value" id="liveDiskValue">0 / 0 GB</div>
+            <div class="kpi-note" id="liveDiskNote">Used / Total</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-title">Online Players</div>
+          <div id="livePlayerList" style="display:flex; flex-wrap:wrap; gap:var(--space-3);">
+            <div style="color:var(--color-text-faint); font-size:var(--text-sm);">No players currently online.</div>
           </div>
         </div>
       </div>
@@ -612,7 +677,9 @@
       console.log("[Playtime] Script starting...");
       const ENABLE_DYNMAP = "{{ENABLE_DYNMAP}}" === "true";
       const DYNMAP_URL = "{{DYNMAP_URL}}";
-      console.log("[Playtime] Dynmap Config:", { ENABLE_DYNMAP, DYNMAP_URL });
+      const ENABLE_LIVE_TAB = "{{ENABLE_LIVE_TAB}}" === "true";
+      const LIVE_UPDATE_INTERVAL = parseInt("{{LIVE_UPDATE_INTERVAL_MS}}") || 3000;
+      console.log("[Playtime] Config:", { ENABLE_DYNMAP, DYNMAP_URL, ENABLE_LIVE_TAB, LIVE_UPDATE_INTERVAL });
       const statusEl = document.getElementById('loadingStatus');
       const crashEl = document.getElementById('crashMessage');
       const overlayEl = document.getElementById('loadingOverlay');
@@ -656,6 +723,9 @@
       let hourlyLocalData = {};
       let hourlyLabelList = [];
       let skinViewer = null;
+      let livePollTimer = null;
+      let liveState = null;
+      const livePlayerElements = new Map(); // Map name -> DOM element
 
       const isUUID = (str) => {
         if (!str || typeof str !== 'string') return false;
@@ -797,7 +867,9 @@
           end = new Date(lastDate.getFullYear(), lastDate.getMonth() + 1, 0);
           today = lastDate;
           const mnames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-          document.getElementById('pageSub').innerHTML = `Combined playtime from join/leave events &middot; ${mnames[firstDate.getMonth()]} ${firstDate.getDate()} &ndash; ${mnames[lastDate.getMonth()]} ${lastDate.getDate()}, ${lastDate.getFullYear()}`;
+          const desc = `Combined playtime from join/leave events &middot; ${mnames[firstDate.getMonth()]} ${firstDate.getDate()} &ndash; ${mnames[lastDate.getMonth()]} ${lastDate.getDate()}, ${lastDate.getFullYear()}`;
+          document.getElementById('pageSub').innerHTML = desc;
+          document.getElementById('pageSubLeaderboards').innerHTML = desc;
         } else {
           start = new Date(); start.setDate(1);
           end = new Date(start.getFullYear(), start.getMonth() + 1, 0);
@@ -1227,18 +1299,47 @@
 
       function jumpToHeatmapDate(dateStr) {
         closePlayerModal();
+        
+        // 1. Reset viewport and switch tab
+        window.scrollTo({ top: 0, behavior: 'instant' });
         const pTab = document.getElementById('tabPlaytime');
         if (pTab) pTab.click();
         
         if (!dateStr) return;
         
+        // 2. Wait for tab to become visible
         setTimeout(() => {
           const cell = document.querySelector(`.day-cell[data-date="${dateStr}"]`);
-          if (cell) {
-            cell.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            setTimeout(() => cell.click(), 400);
+          const section = document.getElementById('heatmapSection');
+          
+          if (cell && section) {
+            // 3. Trigger the panel immediately so we can measure the expanded height
+            cell.click();
+            
+            // 4. Highlight the cell
+            cell.style.outline = "3px solid var(--color-primary)";
+            cell.style.outlineOffset = "4px";
+            cell.style.zIndex = "100";
+            
+            // 5. Short delay to let the panel start opening, then scroll
+            setTimeout(() => {
+              const rect = section.getBoundingClientRect();
+              const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+              
+              // Align the bottom of the section with the bottom of the window
+              const targetY = (rect.bottom + scrollTop) - window.innerHeight + 24; // +24px padding
+              
+              window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+              
+              // 6. Clean up highlight
+              setTimeout(() => {
+                cell.style.outline = "";
+                cell.style.outlineOffset = "";
+                cell.style.zIndex = "";
+              }, 2000);
+            }, 100);
           }
-        }, 100);
+        }, 400);
       }
 
       function showPlayerDetails(name) {
@@ -1453,26 +1554,158 @@
       }
 
       const updateTabs = (activeId) => {
-        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabDynmap'];
-        const views = ['viewPlaytime', 'viewLeaderboards', 'viewDynmap'];
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabLive', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewLive', 'viewDynmap'];
         tabs.forEach((id, i) => {
           const btn = document.getElementById(id);
           const view = document.getElementById(views[i]);
+          if (!btn || !view) return;
           if (id === activeId) {
             btn.classList.add('active');
-            view.style.display = (id === 'viewDynmap' || id === 'tabDynmap') ? 'block' : 'flex';
+            view.style.display = (id === 'tabDynmap' || id === 'tabLive' || id === 'viewDynmap' || id === 'viewLive') ? 'flex' : 'flex'; 
+            // Correct display logic: use flex for all views except maybe dynmap if it prefers block
+            if (id === 'tabDynmap' || id === 'viewDynmap') view.style.display = 'block';
+            else view.style.display = 'flex';
           } else {
             btn.classList.remove('active');
             view.style.display = 'none';
           }
         });
+        
+        if (activeId === 'tabLive') {
+          startLivePolling();
+        } else {
+          stopLivePolling();
+        }
       };
+
+      async function fetchLiveMetrics() {
+        try {
+          const res = await fetch('/api/live');
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          const data = await res.json();
+          liveState = data;
+          renderLive();
+        } catch (e) {
+          console.error("[Live] Polling failed:", e);
+          document.getElementById('liveLastUpdate').textContent = "Connection error: " + e.message;
+          document.getElementById('liveLastUpdate').style.color = "var(--color-primary)";
+        }
+      }
+
+      function startLivePolling() {
+        if (livePollTimer) return;
+        console.log("[Live] Starting polling...");
+        fetchLiveMetrics();
+        livePollTimer = setInterval(fetchLiveMetrics, LIVE_UPDATE_INTERVAL);
+      }
+
+      function stopLivePolling() {
+        if (!livePollTimer) return;
+        console.log("[Live] Stopping polling...");
+        clearInterval(livePollTimer);
+        livePollTimer = null;
+      }
+
+      function renderLive() {
+        if (!liveState) return;
+        
+        const data = liveState;
+        
+        // Players
+        document.getElementById('livePlayersValue').textContent = `${data.playersOnline} / ${data.maxPlayers}`;
+        document.getElementById('livePlayersNote').textContent = data.playersOnline > 0 ? "Active players" : "No players online";
+        
+        // TPS
+        const tps = data.tps.toFixed(1);
+        const tpsEl = document.getElementById('liveTpsValue');
+        tpsEl.textContent = tps;
+        if (data.tps >= 19) tpsEl.style.color = "#67c23a";
+        else if (data.tps >= 15) tpsEl.style.color = "#e6a23c";
+        else tpsEl.style.color = "#f56c6c";
+        
+        // MSPT
+        const msptEl = document.getElementById('liveMsptValue');
+        msptEl.textContent = `${data.mspt.toFixed(1)} ms`;
+        const msptNote = document.getElementById('liveMsptNote');
+        if (data.mspt < 35) { 
+          msptNote.textContent = "Great"; 
+          msptEl.style.color = "#67c23a";
+        } else if (data.mspt < 50) { 
+          msptNote.textContent = "Fair"; 
+          msptEl.style.color = "#e6a23c";
+        } else { 
+          msptNote.textContent = "Heavy Load"; 
+          msptEl.style.color = "#f56c6c";
+        }
+        
+        // CPU
+        const cpuEl = document.getElementById('liveCpuValue');
+        cpuEl.textContent = `${data.cpuProcess.toFixed(1)}%`;
+        if (data.cpuProcess < 60) cpuEl.style.color = "#67c23a";
+        else if (data.cpuProcess < 90) cpuEl.style.color = "#e6a23c";
+        else cpuEl.style.color = "#f56c6c";
+        document.getElementById('liveCpuNote').textContent = "Process Load";
+        
+        // Memory
+        const memEl = document.getElementById('liveMemValue');
+        memEl.textContent = `${data.jvmUsedMb} / ${data.jvmMaxMb} MB`;
+        const memPerc = (data.jvmUsedMb / data.jvmMaxMb) * 100;
+        if (memPerc < 70) memEl.style.color = "#67c23a";
+        else if (memPerc < 90) memEl.style.color = "#e6a23c";
+        else memEl.style.color = "#f56c6c";
+        
+        // Disk (Simplified to only show container size)
+        const worldGb = (data.worldSizeMb / 1024.0).toFixed(1);
+        document.getElementById('liveDiskValue').textContent = `${worldGb} GB`;
+        document.getElementById('liveDiskNote').textContent = "Folder Size";
+        
+        // Player List (Keyed Update to avoid DOM churn)
+        const listEl = document.getElementById('livePlayerList');
+        const newNames = data.playerNames || [];
+        
+        // Remove players who left
+        for (const [name, el] of livePlayerElements.entries()) {
+          if (!newNames.includes(name)) {
+            el.remove();
+            livePlayerElements.delete(name);
+          }
+        }
+        
+        // Add new players
+        newNames.forEach(name => {
+          if (!livePlayerElements.has(name)) {
+            if (livePlayerElements.size === 0 && listEl.children.length === 1 && listEl.children[0].textContent.includes("No players")) {
+              listEl.innerHTML = ""; // Clear placeholder
+            }
+            const div = document.createElement('div');
+            div.className = "live-player-card";
+            div.innerHTML = `
+              ${playerHead(name, 24)}
+              <span>${name}</span>
+            `;
+            div.onclick = () => showPlayerDetails(name);
+            listEl.appendChild(div);
+            livePlayerElements.set(name, div);
+          }
+        });
+
+        if (newNames.length === 0) {
+          listEl.innerHTML = `<div style="color:var(--color-text-faint); font-size:var(--text-sm);">No players currently online.</div>`;
+          livePlayerElements.clear();
+        }
+        
+        const lastUpd = document.getElementById('liveLastUpdate');
+        lastUpd.textContent = "Last update: " + new Date(data.timestamp).toLocaleTimeString();
+        lastUpd.style.color = "var(--color-text-muted)";
+      }
 
       document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
       document.getElementById('tabLeaderboards').addEventListener('click', () => { 
         updateTabs('tabLeaderboards'); 
         if (!leaderboardsData) loadLeaderboards(); 
       });
+      document.getElementById('tabLive').addEventListener('click', () => updateTabs('tabLive'));
       document.getElementById('tabDynmap').addEventListener('click', () => {
         console.log("[Playtime] Switching to Dynmap tab...");
         updateTabs('tabDynmap');
@@ -1486,6 +1719,7 @@
       if (ENABLE_DYNMAP) {
         document.getElementById('tabDynmap').style.display = 'block';
       }
+      // Note: tabLive display is handled by {{LIVE_TAB_DISPLAY}} placeholder in the style attribute
       document.getElementById('btnPie').addEventListener('click', () => { 
         currentViewMode = 'pie'; 
         document.getElementById('btnPie').style.background = 'var(--color-primary)'; 

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -250,6 +250,26 @@
         border-color: var(--color-primary);
         box-shadow: 0 0 0 2px var(--color-primary-highlight);
       }
+      
+      .live-player-card {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-2) var(--space-4);
+        border-radius: var(--radius-lg);
+        background: var(--color-surface-dynamic);
+        border: 1px solid var(--color-border);
+        cursor: pointer;
+        transition: all var(--transition);
+        font-weight: 600;
+        font-size: var(--text-sm);
+      }
+      .live-player-card:hover {
+        background: var(--color-surface-offset);
+        border-color: var(--color-text-faint);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-md);
+      }
       .select-options {
         position: absolute;
         top: calc(100% + 8px);
@@ -427,6 +447,7 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabLive" class="tab-btn" style="display:{{LIVE_TAB_DISPLAY}};">Live</button>
         <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
 
@@ -525,6 +546,7 @@
       </div> <!-- end viewPlaytime -->
 
       <div id="viewLeaderboards" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" id="pageSubLeaderboards" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
         <div class="card">
           <div style="display:flex; gap:var(--space-4); margin-bottom: var(--space-6);">
             <div class="custom-select" id="statSelectContainer" style="flex:1; margin-bottom: 0;">
@@ -560,6 +582,49 @@
                 <!-- Data dynamic -->
               </tbody>
             </table>
+          </div>
+        </div>
+      </div>
+      
+      <div id="viewLive" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" id="liveLastUpdate" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">Last update: never</p>
+        <div class="kpi-row" id="liveKpiRow">
+          <div class="kpi">
+            <div class="kpi-label">Players Online</div>
+            <div class="kpi-value" id="livePlayersValue">0 / 0</div>
+            <div class="kpi-note" id="livePlayersNote">Waiting for data...</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Server TPS</div>
+            <div class="kpi-value" id="liveTpsValue">0.0</div>
+            <div class="kpi-note" id="liveTpsNote">Target 20.0</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Avg MSPT</div>
+            <div class="kpi-value" id="liveMsptValue">0.0 ms</div>
+            <div class="kpi-note" id="liveMsptNote">Target &lt; 50ms</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">CPU Usage</div>
+            <div class="kpi-value" id="liveCpuValue">0%</div>
+            <div class="kpi-note" id="liveCpuNote">Process Load</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Memory Usage</div>
+            <div class="kpi-value" id="liveMemValue">0 / 0 MB</div>
+            <div class="kpi-note" id="liveMemNote">JVM Heap</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Disk Space</div>
+            <div class="kpi-value" id="liveDiskValue">0 / 0 GB</div>
+            <div class="kpi-note" id="liveDiskNote">Used / Total</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-title">Online Players</div>
+          <div id="livePlayerList" style="display:flex; flex-wrap:wrap; gap:var(--space-3);">
+            <div style="color:var(--color-text-faint); font-size:var(--text-sm);">No players currently online.</div>
           </div>
         </div>
       </div>
@@ -612,7 +677,9 @@
       console.log("[Playtime] Script starting...");
       const ENABLE_DYNMAP = "{{ENABLE_DYNMAP}}" === "true";
       const DYNMAP_URL = "{{DYNMAP_URL}}";
-      console.log("[Playtime] Dynmap Config:", { ENABLE_DYNMAP, DYNMAP_URL });
+      const ENABLE_LIVE_TAB = "{{ENABLE_LIVE_TAB}}" === "true";
+      const LIVE_UPDATE_INTERVAL = parseInt("{{LIVE_UPDATE_INTERVAL_MS}}") || 3000;
+      console.log("[Playtime] Config:", { ENABLE_DYNMAP, DYNMAP_URL, ENABLE_LIVE_TAB, LIVE_UPDATE_INTERVAL });
       const statusEl = document.getElementById('loadingStatus');
       const crashEl = document.getElementById('crashMessage');
       const overlayEl = document.getElementById('loadingOverlay');
@@ -656,6 +723,9 @@
       let hourlyLocalData = {};
       let hourlyLabelList = [];
       let skinViewer = null;
+      let livePollTimer = null;
+      let liveState = null;
+      const livePlayerElements = new Map(); // Map name -> DOM element
 
       const isUUID = (str) => {
         if (!str || typeof str !== 'string') return false;
@@ -797,7 +867,9 @@
           end = new Date(lastDate.getFullYear(), lastDate.getMonth() + 1, 0);
           today = lastDate;
           const mnames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-          document.getElementById('pageSub').innerHTML = `Combined playtime from join/leave events &middot; ${mnames[firstDate.getMonth()]} ${firstDate.getDate()} &ndash; ${mnames[lastDate.getMonth()]} ${lastDate.getDate()}, ${lastDate.getFullYear()}`;
+          const desc = `Combined playtime from join/leave events &middot; ${mnames[firstDate.getMonth()]} ${firstDate.getDate()} &ndash; ${mnames[lastDate.getMonth()]} ${lastDate.getDate()}, ${lastDate.getFullYear()}`;
+          document.getElementById('pageSub').innerHTML = desc;
+          document.getElementById('pageSubLeaderboards').innerHTML = desc;
         } else {
           start = new Date(); start.setDate(1);
           end = new Date(start.getFullYear(), start.getMonth() + 1, 0);
@@ -1227,18 +1299,47 @@
 
       function jumpToHeatmapDate(dateStr) {
         closePlayerModal();
+        
+        // 1. Reset viewport and switch tab
+        window.scrollTo({ top: 0, behavior: 'instant' });
         const pTab = document.getElementById('tabPlaytime');
         if (pTab) pTab.click();
         
         if (!dateStr) return;
         
+        // 2. Wait for tab to become visible
         setTimeout(() => {
           const cell = document.querySelector(`.day-cell[data-date="${dateStr}"]`);
-          if (cell) {
-            cell.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            setTimeout(() => cell.click(), 400);
+          const section = document.getElementById('heatmapSection');
+          
+          if (cell && section) {
+            // 3. Trigger the panel immediately so we can measure the expanded height
+            cell.click();
+            
+            // 4. Highlight the cell
+            cell.style.outline = "3px solid var(--color-primary)";
+            cell.style.outlineOffset = "4px";
+            cell.style.zIndex = "100";
+            
+            // 5. Short delay to let the panel start opening, then scroll
+            setTimeout(() => {
+              const rect = section.getBoundingClientRect();
+              const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+              
+              // Align the bottom of the section with the bottom of the window
+              const targetY = (rect.bottom + scrollTop) - window.innerHeight + 24; // +24px padding
+              
+              window.scrollTo({ top: Math.max(0, targetY), behavior: 'smooth' });
+              
+              // 6. Clean up highlight
+              setTimeout(() => {
+                cell.style.outline = "";
+                cell.style.outlineOffset = "";
+                cell.style.zIndex = "";
+              }, 2000);
+            }, 100);
           }
-        }, 100);
+        }, 400);
       }
 
       function showPlayerDetails(name) {
@@ -1453,26 +1554,158 @@
       }
 
       const updateTabs = (activeId) => {
-        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabDynmap'];
-        const views = ['viewPlaytime', 'viewLeaderboards', 'viewDynmap'];
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabLive', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewLive', 'viewDynmap'];
         tabs.forEach((id, i) => {
           const btn = document.getElementById(id);
           const view = document.getElementById(views[i]);
+          if (!btn || !view) return;
           if (id === activeId) {
             btn.classList.add('active');
-            view.style.display = (id === 'viewDynmap' || id === 'tabDynmap') ? 'block' : 'flex';
+            view.style.display = (id === 'tabDynmap' || id === 'tabLive' || id === 'viewDynmap' || id === 'viewLive') ? 'flex' : 'flex'; 
+            // Correct display logic: use flex for all views except maybe dynmap if it prefers block
+            if (id === 'tabDynmap' || id === 'viewDynmap') view.style.display = 'block';
+            else view.style.display = 'flex';
           } else {
             btn.classList.remove('active');
             view.style.display = 'none';
           }
         });
+        
+        if (activeId === 'tabLive') {
+          startLivePolling();
+        } else {
+          stopLivePolling();
+        }
       };
+
+      async function fetchLiveMetrics() {
+        try {
+          const res = await fetch('/api/live');
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          const data = await res.json();
+          liveState = data;
+          renderLive();
+        } catch (e) {
+          console.error("[Live] Polling failed:", e);
+          document.getElementById('liveLastUpdate').textContent = "Connection error: " + e.message;
+          document.getElementById('liveLastUpdate').style.color = "var(--color-primary)";
+        }
+      }
+
+      function startLivePolling() {
+        if (livePollTimer) return;
+        console.log("[Live] Starting polling...");
+        fetchLiveMetrics();
+        livePollTimer = setInterval(fetchLiveMetrics, LIVE_UPDATE_INTERVAL);
+      }
+
+      function stopLivePolling() {
+        if (!livePollTimer) return;
+        console.log("[Live] Stopping polling...");
+        clearInterval(livePollTimer);
+        livePollTimer = null;
+      }
+
+      function renderLive() {
+        if (!liveState) return;
+        
+        const data = liveState;
+        
+        // Players
+        document.getElementById('livePlayersValue').textContent = `${data.playersOnline} / ${data.maxPlayers}`;
+        document.getElementById('livePlayersNote').textContent = data.playersOnline > 0 ? "Active players" : "No players online";
+        
+        // TPS
+        const tps = data.tps.toFixed(1);
+        const tpsEl = document.getElementById('liveTpsValue');
+        tpsEl.textContent = tps;
+        if (data.tps >= 19) tpsEl.style.color = "#67c23a";
+        else if (data.tps >= 15) tpsEl.style.color = "#e6a23c";
+        else tpsEl.style.color = "#f56c6c";
+        
+        // MSPT
+        const msptEl = document.getElementById('liveMsptValue');
+        msptEl.textContent = `${data.mspt.toFixed(1)} ms`;
+        const msptNote = document.getElementById('liveMsptNote');
+        if (data.mspt < 35) { 
+          msptNote.textContent = "Great"; 
+          msptEl.style.color = "#67c23a";
+        } else if (data.mspt < 50) { 
+          msptNote.textContent = "Fair"; 
+          msptEl.style.color = "#e6a23c";
+        } else { 
+          msptNote.textContent = "Heavy Load"; 
+          msptEl.style.color = "#f56c6c";
+        }
+        
+        // CPU
+        const cpuEl = document.getElementById('liveCpuValue');
+        cpuEl.textContent = `${data.cpuProcess.toFixed(1)}%`;
+        if (data.cpuProcess < 60) cpuEl.style.color = "#67c23a";
+        else if (data.cpuProcess < 90) cpuEl.style.color = "#e6a23c";
+        else cpuEl.style.color = "#f56c6c";
+        document.getElementById('liveCpuNote').textContent = "Process Load";
+        
+        // Memory
+        const memEl = document.getElementById('liveMemValue');
+        memEl.textContent = `${data.jvmUsedMb} / ${data.jvmMaxMb} MB`;
+        const memPerc = (data.jvmUsedMb / data.jvmMaxMb) * 100;
+        if (memPerc < 70) memEl.style.color = "#67c23a";
+        else if (memPerc < 90) memEl.style.color = "#e6a23c";
+        else memEl.style.color = "#f56c6c";
+        
+        // Disk (Simplified to only show container size)
+        const worldGb = (data.worldSizeMb / 1024.0).toFixed(1);
+        document.getElementById('liveDiskValue').textContent = `${worldGb} GB`;
+        document.getElementById('liveDiskNote').textContent = "Folder Size";
+        
+        // Player List (Keyed Update to avoid DOM churn)
+        const listEl = document.getElementById('livePlayerList');
+        const newNames = data.playerNames || [];
+        
+        // Remove players who left
+        for (const [name, el] of livePlayerElements.entries()) {
+          if (!newNames.includes(name)) {
+            el.remove();
+            livePlayerElements.delete(name);
+          }
+        }
+        
+        // Add new players
+        newNames.forEach(name => {
+          if (!livePlayerElements.has(name)) {
+            if (livePlayerElements.size === 0 && listEl.children.length === 1 && listEl.children[0].textContent.includes("No players")) {
+              listEl.innerHTML = ""; // Clear placeholder
+            }
+            const div = document.createElement('div');
+            div.className = "live-player-card";
+            div.innerHTML = `
+              ${playerHead(name, 24)}
+              <span>${name}</span>
+            `;
+            div.onclick = () => showPlayerDetails(name);
+            listEl.appendChild(div);
+            livePlayerElements.set(name, div);
+          }
+        });
+
+        if (newNames.length === 0) {
+          listEl.innerHTML = `<div style="color:var(--color-text-faint); font-size:var(--text-sm);">No players currently online.</div>`;
+          livePlayerElements.clear();
+        }
+        
+        const lastUpd = document.getElementById('liveLastUpdate');
+        lastUpd.textContent = "Last update: " + new Date(data.timestamp).toLocaleTimeString();
+        lastUpd.style.color = "var(--color-text-muted)";
+      }
 
       document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
       document.getElementById('tabLeaderboards').addEventListener('click', () => { 
         updateTabs('tabLeaderboards'); 
         if (!leaderboardsData) loadLeaderboards(); 
       });
+      document.getElementById('tabLive').addEventListener('click', () => updateTabs('tabLive'));
       document.getElementById('tabDynmap').addEventListener('click', () => {
         console.log("[Playtime] Switching to Dynmap tab...");
         updateTabs('tabDynmap');
@@ -1486,6 +1719,7 @@
       if (ENABLE_DYNMAP) {
         document.getElementById('tabDynmap').style.display = 'block';
       }
+      // Note: tabLive display is handled by {{LIVE_TAB_DISPLAY}} placeholder in the style attribute
       document.getElementById('btnPie').addEventListener('click', () => { 
         currentViewMode = 'pie'; 
         document.getElementById('btnPie').style.background = 'var(--color-primary)'; 


### PR DESCRIPTION
This PR adds a new 'Live' tab to the Minecraft Activity Dashboard, providing real-time server performance metrics and online player monitoring.

Key Features:
- Real-time TPS, MSPT, CPU, and Memory monitoring.
- Live disk space reporting for `/home/container/` (folder size).
- Interactive 'Online Players' list with clickable player cards.
- Optimized polling logic and keyed DOM updates to ensure zero lag.
- Enhanced navigation from 'Live' to historical 'Playtime' stats.
- Color-coded performance indicators for at-a-glance health checks.