### PR TITLE
feat: playstyle synchronization and UI navigation enhancements

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
+++ b/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -48,6 +49,7 @@ public class StatsAggregator {
     public Map<String, Map<String, Map<String, Integer>>> buildLeaderboards(Path statsDir, UuidCache uuidCache) {
         // Map<Category, Map<Stat, Map<PlayerName, Value>>>
         Map<String, Map<String, Map<String, Integer>>> result = new LinkedHashMap<>();
+        Map<String, String> playerToUuid = new HashMap<>();
 
         File[] files = statsDir.toFile().listFiles((d, n) -> n.endsWith(".json"));
         if (files == null) return result;
@@ -58,17 +60,15 @@ public class StatsAggregator {
             try {
                 uuid = UUID.fromString(uuidStr);
             } catch (IllegalArgumentException e) {
-                continue; // Not a valid UUID file name
+                continue;
             }
 
             String rawName = uuidCache.getUsername(uuid).orElse(uuidStr);
             String playerName = normalizePlayer(rawName, uuidStr);
+            
+            if (isUuidString(playerName)) continue;
 
-            // Skip players that couldn't be resolved to a name (even after Mojang API check)
-            // and are still just raw UUID strings, to prevent UI clutter.
-            if (isUuidString(playerName)) {
-                continue;
-            }
+            playerToUuid.putIfAbsent(playerName, uuidStr);
 
             try (JsonReader reader = new JsonReader(new FileReader(statFile))) {
                 parseStatsIntoMap(reader, playerName, result);
@@ -76,6 +76,10 @@ public class StatsAggregator {
                 FabricDashboardMod.LOGGER.warn("Skipping malformed stats file: " + statFile.getName());
             }
         }
+
+        // --- Post-process Playstyle Leaderboards ---
+        calculateAndInjectPlaystyleScores(result, playerToUuid, statsDir.getParent());
+
         return result;
     }
 
@@ -104,12 +108,14 @@ public class StatsAggregator {
     }
 
     private void parseStatsIntoMap(JsonReader reader, String playerName, Map<String, Map<String, Map<String, Integer>>> result) throws IOException {
-        reader.beginObject(); // start main object
+        reader.beginObject();
         long distanceCm = 0;
         int damageTaken = 0;
         int damageDealt = 0;
         int totalMined = 0;
         int totalUsed = 0;
+        int redstoneUsed = 0;
+        int mobKills = 0;
 
         Map<String, Map<String, Integer>> filteredCategory = result.computeIfAbsent("general", k -> new LinkedHashMap<>());
 
@@ -126,8 +132,9 @@ public class StatsAggregator {
 
                         if ("minecraft:mined".equals(category)) {
                             totalMined += value;
-                        } else if ("minecraft:used".equals(category) && isBlockPlacement(stat)) {
-                            totalUsed += value;
+                        } else if ("minecraft:used".equals(category)) {
+                            if (isBlockPlacement(stat)) totalUsed += value;
+                            if (isRedstone(stat)) redstoneUsed += value;
                         }
 
                         if (stat.endsWith("_one_cm")) {
@@ -136,8 +143,10 @@ public class StatsAggregator {
                             damageTaken += value;
                         } else if (stat.equals("minecraft:damage_dealt")) {
                             damageDealt += value;
+                        } else if (stat.equals("minecraft:mob_kills")) {
+                            mobKills += value;
+                            addGeneralStat(filteredCategory, playerName, "mob_kills", value);
                         } else if (stat.equals("minecraft:player_kills") || 
-                                   stat.equals("minecraft:mob_kills") || 
                                    stat.equals("minecraft:deaths") || 
                                    stat.equals("minecraft:sleep_in_bed") || 
                                    stat.equals("minecraft:talked_to_villager") || 
@@ -147,55 +156,170 @@ public class StatsAggregator {
                                    stat.equals("minecraft:ender_dragon") || 
                                    stat.contains("dragon_fish")) {
                             
-                            // normalize stat names a bit to make frontend easier
                             String key = stat.replace("minecraft:", "").replace("tide:", "");
-                            if (key.contains("dragon_fish")) {
-                                key = "dragon_fish";
-                            }
-                            Map<String, Integer> statMap = filteredCategory.computeIfAbsent(key, k -> new LinkedHashMap<>());
-                            statMap.merge(playerName, value, Integer::sum);
+                            if (key.contains("dragon_fish")) key = "dragon_fish";
+                            addGeneralStat(filteredCategory, playerName, key, value);
                         }
                     }
                     reader.endObject();
                 }
                 reader.endObject();
             } else {
-                reader.skipValue(); // e.g. DataVersion
+                reader.skipValue();
             }
         }
-        reader.endObject();
-
         if (distanceCm > 0) {
-            filteredCategory.computeIfAbsent("distance_traveled_km", k -> new LinkedHashMap<>())
-                    .merge(playerName, (int)(distanceCm / 100000L), Integer::sum);
-        }
-        if (damageTaken > 0) {
-            filteredCategory.computeIfAbsent("damage_taken_hearts", k -> new LinkedHashMap<>())
-                    .merge(playerName, damageTaken / 10, Integer::sum);
+            addGeneralStat(filteredCategory, playerName, "distance_traveled_raw_cm", (int)distanceCm);
+            addGeneralStat(filteredCategory, playerName, "distance_traveled_km", (int)(distanceCm / 100000L));
         }
         if (damageDealt > 0) {
-            filteredCategory.computeIfAbsent("damage_dealt_hearts", k -> new LinkedHashMap<>())
-                    .merge(playerName, damageDealt / 10, Integer::sum);
+            addGeneralStat(filteredCategory, playerName, "damage_dealt_hearts", damageDealt / 10);
         }
         if (totalMined > 0) {
-            filteredCategory.computeIfAbsent("total_blocks_broken", k -> new LinkedHashMap<>())
-                    .merge(playerName, totalMined, Integer::sum);
+            addGeneralStat(filteredCategory, playerName, "total_blocks_broken", totalMined);
         }
         if (totalUsed > 0) {
-            filteredCategory.computeIfAbsent("total_blocks_placed", k -> new LinkedHashMap<>())
-                    .merge(playerName, totalUsed, Integer::sum);
+            addGeneralStat(filteredCategory, playerName, "total_blocks_placed", totalUsed);
+        }
+        if (redstoneUsed > 0) {
+            addGeneralStat(filteredCategory, playerName, "redstone_used_raw", redstoneUsed);
+        }
+
+        reader.endObject();
+    }
+
+    private void calculateAndInjectPlaystyleScores(Map<String, Map<String, Map<String, Integer>>> result, Map<String, String> playerToUuid, Path worldDir) {
+        Map<String, Map<String, Integer>> general = result.get("general");
+        if (general == null) return;
+
+        Map<String, Integer> distRaw = general.get("distance_traveled_raw_cm");
+        Map<String, Integer> blocksPlaced = general.get("total_blocks_placed");
+        Map<String, Integer> blocksBroken = general.get("total_blocks_broken");
+        Map<String, Integer> mobKills = general.get("mob_kills");
+        Map<String, Integer> damageHearts = general.get("damage_dealt_hearts");
+        Map<String, Integer> redstoneRaw = general.get("redstone_used_raw");
+
+        Set<String> allPlayers = new HashSet<>();
+        if (distRaw != null) allPlayers.addAll(distRaw.keySet());
+        if (blocksPlaced != null) allPlayers.addAll(blocksPlaced.keySet());
+        if (blocksBroken != null) allPlayers.addAll(blocksBroken.keySet());
+        if (mobKills != null) allPlayers.addAll(mobKills.keySet());
+        if (damageHearts != null) allPlayers.addAll(damageHearts.keySet());
+        if (redstoneRaw != null) allPlayers.addAll(redstoneRaw.keySet());
+
+        for (String player : allPlayers) {
+            String uuid = playerToUuid.get(player);
+            File advFile = worldDir.resolve("advancements").resolve(uuid + ".json").toFile();
+            int[] advBonuses = getAdvancementBonus(advFile);
+
+            long distKm = (distRaw != null && distRaw.containsKey(player)) ? (distRaw.get(player) / 100000L) : 0L;
+            int placed = (blocksPlaced != null) ? blocksPlaced.getOrDefault(player, 0) : 0;
+            int broken = (blocksBroken != null) ? blocksBroken.getOrDefault(player, 0) : 0;
+            int kills = (mobKills != null) ? mobKills.getOrDefault(player, 0) : 0;
+            int hearts = (damageHearts != null) ? damageHearts.getOrDefault(player, 0) : 0;
+            int rsUsed = (redstoneRaw != null) ? redstoneRaw.getOrDefault(player, 0) : 0;
+
+            // Explorer (5000km cap)
+            double expBase = Math.min(100.0, (distKm / 5000.0) * 100.0);
+            int expFinal = (int) Math.min(100, Math.max(5, expBase + Math.min(30, advBonuses[0])));
+
+            // Builder (500,000 action cap)
+            double bldBase = Math.min(100.0, ((placed + broken / 4.0) / 500000.0) * 100.0);
+            int bldFinal = (int) Math.min(100, Math.max(5, bldBase + Math.min(30, advBonuses[1])));
+
+            // Fighter (150,000 combat cap)
+            double fgtBase = Math.min(100.0, ((kills + hearts / 10.0) / 150000.0) * 100.0);
+            int fgtFinal = (int) Math.min(100, Math.max(5, fgtBase + Math.min(30, advBonuses[2])));
+
+            // Redstoner (7,500 interaction cap)
+            double redBase = Math.min(100.0, (rsUsed / 7500.0) * 100.0);
+            int redFinal = (int) Math.min(100, Math.max(5, redBase + Math.min(30, advBonuses[3])));
+
+            addGeneralStat(general, player, "playstyle_explorer", expFinal);
+            addGeneralStat(general, player, "playstyle_builder", bldFinal);
+            addGeneralStat(general, player, "playstyle_fighter", fgtFinal);
+            addGeneralStat(general, player, "playstyle_redstoner", redFinal);
         }
     }
 
+    private int[] getAdvancementBonus(File advFile) {
+        int[] bonuses = new int[4];
+        if (advFile == null || !advFile.exists()) return bonuses;
+
+        try (JsonReader reader = new JsonReader(new FileReader(advFile))) {
+            reader.beginObject();
+            while (reader.hasNext()) {
+                String advId = reader.nextName().toLowerCase();
+                reader.beginObject();
+                boolean done = false;
+                while (reader.hasNext()) {
+                    String key = reader.nextName();
+                    if ("done".equals(key)) {
+                        done = reader.nextBoolean();
+                    } else {
+                        reader.skipValue();
+                    }
+                }
+                reader.endObject();
+
+                if (done) {
+                    if (containsAny(advId, "explore", "discover", "travel", "biome", "adventure")) bonuses[0] += 5;
+                    if (containsAny(advId, "build", "construct", "place", "craft")) bonuses[1] += 5;
+                    if (containsAny(advId, "kill", "slay", "monster", "combat", "boss")) bonuses[2] += 5;
+                    if (containsAny(advId, "redstone", "machine", "circuit", "automation")) bonuses[3] += 5;
+                }
+            }
+            reader.endObject();
+        } catch (Exception e) {
+            // malformed or empty advancement file
+        }
+        return bonuses;
+    }
+
+    private boolean containsAny(String str, String... keywords) {
+        for (String k : keywords) {
+            if (str.contains(k)) return true;
+        }
+        return false;
+    }
+
+    private void addGeneralStat(Map<String, Map<String, Integer>> filteredCategory, String playerName, String key, int value) {
+        Map<String, Integer> statMap = filteredCategory.computeIfAbsent(key, k -> new LinkedHashMap<>());
+        statMap.merge(playerName, value, Integer::sum);
+    }
+
+    private boolean isRedstone(String stat) {
+        String id = stat.replace("minecraft:", "");
+        for (String rs : REDSTONE_ITEMS) {
+            if (id.equals(rs) || id.contains(rs)) return true;
+        }
+        return false;
+    }
+
+    private static final String[] REDSTONE_ITEMS = {
+        "redstone", "repeater", "comparator", "observer", "piston", "sticky_piston", 
+        "redstone_torch", "lever", "daylight_detector", "target", "sculk_sensor", 
+        "dropper", "dispenser", "hopper", "trapped_chest", "tnt", "tnt_minecart", 
+        "redstone_lamp", "redstone_block", "tripwire_hook", "sculk_shrieker", "sculk_catalyst"
+    };
+
     public void streamPlayerStats(String username, UuidCache uuidCache, Path statsDir, OutputStream out) throws IOException {
+        streamFile(username, uuidCache, statsDir, out, "stats");
+    }
+
+    public void streamPlayerAdvancements(String username, UuidCache uuidCache, Path advancementsDir, OutputStream out) throws IOException {
+        streamFile(username, uuidCache, advancementsDir, out, "advancements");
+    }
+
+    private void streamFile(String username, UuidCache uuidCache, Path dir, OutputStream out, String type) throws IOException {
         Optional<UUID> uuid = uuidCache.getUuid(username);
         
         if (uuid.isEmpty()) {
             // First check if the username itself is just a raw UUID string
             try {
                 uuid = Optional.of(UUID.fromString(username));
-                if (!Files.exists(statsDir.resolve(uuid.get() + ".json"))) {
-                    uuid = Optional.empty(); // Not a valid stat file, fallback to alias search
+                if (!Files.exists(dir.resolve(uuid.get() + ".json"))) {
+                    uuid = Optional.empty(); // Not a valid file, fallback to alias search
                 }
             } catch (IllegalArgumentException e) {
                 // Not a UUID string, proceed with alias search
@@ -218,7 +342,7 @@ public class StatsAggregator {
                             } catch (IllegalArgumentException e) {
                                 uuid = uuidCache.getUuid(entry.getKey());
                             }
-                            if (uuid.isPresent() && Files.exists(statsDir.resolve(uuid.get() + ".json"))) {
+                            if (uuid.isPresent() && Files.exists(dir.resolve(uuid.get() + ".json"))) {
                                 break;
                             }
                         }
@@ -231,13 +355,13 @@ public class StatsAggregator {
             throw new FileNotFoundException("Unknown player: " + username);
         }
 
-        Path statFile = statsDir.resolve(uuid.get() + ".json");
-        if (!Files.exists(statFile)) {
-            throw new FileNotFoundException("No stats for: " + username);
+        Path file = dir.resolve(uuid.get() + ".json");
+        if (!Files.exists(file)) {
+            throw new FileNotFoundException("No " + type + " for: " + username);
         }
 
-        // Act as a pure pipe — never parse the JSON
-        try (InputStream in = Files.newInputStream(statFile)) {
+        // Act as a pure pipe
+        try (InputStream in = Files.newInputStream(file)) {
             byte[] buffer = new byte[8192];
             int read;
             while ((read = in.read(buffer)) != -1) {

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -111,6 +111,7 @@ public class DashboardWebServer {
             httpServer.createContext("/skins/", new SkinHandler(headService));
             httpServer.createContext("/api/leaderboards", new LeaderboardHandler(leaderboardCacheFile));
             httpServer.createContext("/api/player-stats/", new PlayerStatsHandler(statsAggregator, uuidCache));
+            httpServer.createContext("/api/player-advancements/", new PlayerAdvancementsHandler(statsAggregator, uuidCache));
             httpServer.createContext("/api/live", new LiveMetricsHandler(this));
             
             httpServer.setExecutor(Executors.newFixedThreadPool(2));

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerAdvancementsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerAdvancementsHandler.java
@@ -1,0 +1,96 @@
+package com.playtime.dashboard.web;
+
+import com.playtime.dashboard.FabricDashboardMod;
+import com.playtime.dashboard.config.DashboardConfig;
+import com.playtime.dashboard.stats.StatsAggregator;
+import com.playtime.dashboard.util.UuidCache;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+public class PlayerAdvancementsHandler implements HttpHandler {
+    private final StatsAggregator statsAggregator;
+    private final UuidCache uuidCache;
+
+    public PlayerAdvancementsHandler(StatsAggregator statsAggregator, UuidCache uuidCache) {
+        this.statsAggregator = statsAggregator;
+        this.uuidCache = uuidCache;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        String path = exchange.getRequestURI().getPath();
+        String prefix = "/api/player-advancements/";
+        if (!path.startsWith(prefix)) {
+            exchange.sendResponseHeaders(404, -1);
+            return;
+        }
+
+        String username = path.substring(prefix.length());
+        
+        if (!username.matches("[\\w/\\-]+")) {
+            sendError(exchange, 400, "Invalid username format");
+            return;
+        }
+
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+        exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+        exchange.getResponseHeaders().set("Pragma", "no-cache");
+        exchange.getResponseHeaders().set("Expires", "0");
+
+        Path baseAdvancementsDir = FabricLoader.getInstance().getGameDir()
+                .resolve(DashboardConfig.get().stats_world_name)
+                .resolve("advancements");
+
+        OutputStream lazyOut = new OutputStream() {
+            private OutputStream real = null;
+            private void init() throws IOException {
+                if (real == null) {
+                    exchange.sendResponseHeaders(200, 0); // chunked response
+                    real = exchange.getResponseBody();
+                }
+            }
+            @Override public void write(int b) throws IOException { init(); real.write(b); }
+            @Override public void write(byte[] b, int off, int len) throws IOException { init(); real.write(b, off, len); }
+            @Override public void close() throws IOException {
+                if (real == null) { // Empty file, send empty success if it reached here
+                    exchange.sendResponseHeaders(200, 0);
+                    real = exchange.getResponseBody();
+                }
+                real.close();
+            }
+            @Override public void flush() throws IOException { if (real != null) real.flush(); }
+        };
+
+        try {
+            statsAggregator.streamPlayerAdvancements(username, uuidCache, baseAdvancementsDir, lazyOut);
+            lazyOut.close();
+        } catch (FileNotFoundException e) {
+            sendError(exchange, 404, "Advancements not found");
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("PlayerAdvancementsHandler: Error serving advancements for '" + username + "'", e);
+            sendError(exchange, 500, "Internal Server Error");
+        }
+    }
+
+    private void sendError(HttpExchange exchange, int code, String message) throws IOException {
+        String json = "{\"error\":\"" + message + "\"}";
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+        exchange.sendResponseHeaders(code, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -76,6 +76,14 @@
         display:flex;flex-direction:column;justify-content:space-between;}
       .kpi-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:500;}
       .kpi-value{font-size:var(--text-lg);font-weight:700;letter-spacing:-0.02em;margin-block:auto;padding-block:var(--space-2);}
+      .kpi-value.interactive {
+        cursor: pointer;
+        transition: all var(--transition);
+      }
+      .kpi-value.interactive:hover {
+        color: var(--color-primary);
+        transform: scale(1.02);
+      }
       .kpi-note{font-size:var(--text-xs);color:var(--color-text-faint);}
 
       /* Card */
@@ -93,6 +101,64 @@
         border-color: var(--color-primary);
         transform: translateY(-4px);
         box-shadow: var(--shadow-md);
+      }
+
+      .status-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        display: inline-block;
+        cursor: pointer;
+        transition: all var(--transition);
+        position: relative;
+      }
+      .status-dot:hover { transform: scale(1.25); }
+      .status-online { background-color: #67c23a; box-shadow: 0 0 10px rgba(103, 194, 58, 0.6); }
+      .status-offline { background-color: #f56c6c; box-shadow: 0 0 5px rgba(245, 108, 108, 0.3); }
+
+      .status-tooltip {
+        position: absolute;
+        left: calc(100% + 10px);
+        top: 50%;
+        transform: translateY(-50%) translateX(-10px);
+        background: var(--color-surface-2);
+        border: 1px solid var(--color-border);
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-md);
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        white-space: nowrap;
+        opacity: 0;
+        pointer-events: none;
+        transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+        z-index: 100;
+        box-shadow: var(--shadow-md);
+        color: var(--color-text);
+      }
+      .status-dot:hover .status-tooltip {
+        opacity: 1;
+        transform: translateY(-50%) translateX(0);
+      }
+      .status-tooltip::before {
+        content: '';
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        border: 5px solid transparent;
+        border-right-color: var(--color-border);
+      }
+      .status-tooltip::after {
+        content: '';
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        margin-right: -1px;
+        border: 5px solid transparent;
+        border-right-color: var(--color-surface-2);
       }
 
       /* Heatmap + pie layout */
@@ -157,10 +223,19 @@
       .pie-wrap{position:relative;width:100%;max-width:320px;margin-inline:auto;display:flex;align-items:center;}
       .pie-wrap canvas{width:100%!important;height:auto!important;}
       .pie-legend{display:flex;flex-direction:column;gap:var(--space-2);margin-top:var(--space-3);}
-      .pie-legend-item{display:flex;align-items:center;justify-content:space-between;font-size:var(--text-xs);}
+      .pie-legend-item{display:flex;align-items:center;justify-content:space-between;font-size:var(--text-xs);
+        padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); transition: all var(--transition);}
+      .pie-legend-item[onclick]:hover { background: var(--color-surface-dynamic); transform: translateX(4px); }
       .pie-legend-name{display:flex;align-items:center;gap:var(--space-2);color:var(--color-text-muted);}
       .pie-dot{width:9px;height:9px;border-radius:50%;flex-shrink:0;}
       .pie-legend-val{font-weight:500;color:var(--color-text);}
+
+      .breakdown-row {
+        display:flex; align-items:center; gap:var(--space-3); margin-bottom:var(--space-2);
+        padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm);
+        transition: all var(--transition); cursor: pointer;
+      }
+      .breakdown-row:hover { background: var(--color-surface-dynamic); transform: translateX(4px); }
 
       /* Player head images */
       .player-head{border-radius:var(--radius-sm);image-rendering:pixelated;vertical-align:middle;flex-shrink:0;}
@@ -381,7 +456,7 @@
         flex-direction: column; 
         gap: var(--space-6); 
         overflow-y: auto;
-        overflow-x: hidden;
+        overflow-x: visible;
         height: 100%;
       }
       .modal-player-header { display: flex; align-items: center; gap: var(--space-4); }
@@ -593,7 +668,7 @@
         <div class="card" style="height:fit-content; padding: var(--space-5);">
           <div style="margin-bottom: var(--space-5);">
             <div class="card-title" style="margin-bottom: var(--space-3);">
-              Daily Playtime Calendar <span class="card-subtitle">click a day to see breakdown</span>
+              Playtime Calendar <span class="card-subtitle">click a day to see breakdown</span>
             </div>
             <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-4);">
               <div style="position: relative; width: 240px;">
@@ -662,7 +737,7 @@
 
       <div class="card" id="playerTableCard">
         <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--space-5);">
-          <div class="card-title" style="margin-bottom:0;">Player Breakdown <span class="card-subtitle">total session time</span></div>
+          <div class="card-title" style="margin-bottom:0;">Playtime Breakdown <span class="card-subtitle">total session time</span></div>
           
           <div class="custom-select" id="playerSortContainer" style="margin-bottom: 0; width: 180px;">
             <div class="select-trigger" onclick="togglePlayerSortDropdown()">
@@ -791,26 +866,37 @@
             <div class="modal-player-header">
               <div id="modalPlayerHead"></div>
               <div class="modal-player-name" id="modalPlayerName">PlayerName</div>
+              <div id="modalPlayerStatus" class="status-dot">
+                <div id="modalPlayerStatusTooltip" class="status-tooltip">Offline</div>
+              </div>
             </div>
 
             <div class="modal-tabs">
               <div class="modal-tab active" id="tabModalPlaytime" onclick="switchModalTab('playtime')">Playtime Stats</div>
               <div class="modal-tab" id="tabModalIngame" onclick="switchModalTab('ingame')">In-Game Stats</div>
+              <div class="modal-tab" id="tabModalPlaystyle" onclick="switchModalTab('playstyle')">Playstyle</div>
             </div>
-
             <div id="modalContentPlaytime">
-              <div class="modal-stats-grid" id="modalStats">
-                <!-- Stats dynamic -->
+              <div class="modal-stats-grid" id="modalStats"></div>
+            </div>
+
+            <div id="modalContentIngame" style="display:none; flex-direction:column; gap:var(--space-4);">
+              <div id="modalIngameStats"></div>
+            </div>
+
+            <div id="modalContentPlaystyle" style="display:none; flex-direction:column; gap:var(--space-2); height: 100%;">
+              <div style="text-align: center; margin-top: var(--space-4);">
+                <div style="width: 100%; margin: 0 auto; aspect-ratio: 1/1; position: relative;">
+                  <canvas id="playstyleChart"></canvas>
+                </div>
+              </div>
+              <div style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                <span style="font-weight: 500;">Calculated from latest server logs</span>
               </div>
             </div>
 
-            <div id="modalContentIngame" style="display:none; flex-direction:column;">
-              <div id="modalIngameStats" style="overflow-y:auto; padding-right:var(--space-2);">
-                Loading...
-              </div>
-            </div>
-
-            <div style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
+            <div id="modalFooterGlobal" style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
               <span style="font-weight: 500;">Calculated from latest server logs</span>
             </div>
@@ -886,6 +972,10 @@
       const rankClass = ['rank-1', 'rank-2', 'rank-3'];
       const STAT_CONFIG = [
         { id: 'distance_traveled_km', name: 'Total Distance Traveled', label: 'Distance Traveled', suffix: ' km' },
+        { id: 'playstyle_explorer', name: 'Playstyle: Explorer', label: 'Explorer Score', suffix: '%' },
+        { id: 'playstyle_builder', name: 'Playstyle: Builder', label: 'Builder Score', suffix: '%' },
+        { id: 'playstyle_fighter', name: 'Playstyle: Fighter', label: 'Fighter Score', suffix: '%' },
+        { id: 'playstyle_redstoner', name: 'Playstyle: Redstoner', label: 'Redstoner Score', suffix: '%' },
         { id: 'total_blocks_broken', name: 'Total Blocks Broken', label: 'Blocks Broken', suffix: '' },
         { id: 'total_blocks_placed', name: 'Total Blocks Placed', label: 'Blocks Placed', suffix: '' },
         { id: 'player_kills', name: 'Players Killed', label: 'Players Killed', suffix: '' },
@@ -940,19 +1030,35 @@
       function switchModalTab(tab) {
         const pTab = document.getElementById('tabModalPlaytime');
         const iTab = document.getElementById('tabModalIngame');
+        const sTab = document.getElementById('tabModalPlaystyle');
         const pContent = document.getElementById('modalContentPlaytime');
         const iContent = document.getElementById('modalContentIngame');
+        const sContent = document.getElementById('modalContentPlaystyle');
+        const globalFooter = document.getElementById('modalFooterGlobal');
+
+        pTab.classList.remove('active');
+        iTab.classList.remove('active');
+        sTab.classList.remove('active');
+        pContent.style.display = 'none';
+        iContent.style.display = 'none';
+        sContent.style.display = 'none';
+        if (globalFooter) globalFooter.style.display = 'flex';
 
         if (tab === 'playtime') {
           pTab.classList.add('active');
-          iTab.classList.remove('active');
           pContent.style.display = 'block';
-          iContent.style.display = 'none';
-        } else {
+        } else if (tab === 'ingame') {
           iTab.classList.add('active');
-          pTab.classList.remove('active');
           iContent.style.display = 'flex';
-          pContent.style.display = 'none';
+        } else if (tab === 'playstyle') {
+          sTab.classList.add('active');
+          sContent.style.display = 'flex';
+          if (globalFooter) globalFooter.style.display = 'none';
+          // Force immediate resize update in case it was pre-loaded while hidden
+          if (window.playstyleChartObj) {
+            window.playstyleChartObj.resize();
+            window.playstyleChartObj.update('none');
+          }
         }
       }
 
@@ -989,13 +1095,13 @@
           </div>
           <div class="kpi">
             <div class="kpi-label">Busiest Day</div>
-            <div class="kpi-value">${months[maxDate.getMonth()]} ${maxDate.getDate()}</div>
+            <div class="kpi-value interactive" onclick="jumpToHeatmapDate('${maxDay ? maxDay[0] : ''}')">${months[maxDate.getMonth()]} ${maxDate.getDate()}</div>
             <div class="kpi-note">${maxDay ? maxDay[1].toFixed(1) : 0}h of playtime</div>
           </div>
           ${top3.map(([p,m],i) => `
           <div class="kpi">
             <div class="kpi-label">${rankLabels[i]}</div>
-            <div class="kpi-value" style="font-size:var(--text-sm);font-weight:700;display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;word-break:break-all;">
+            <div class="kpi-value interactive" onclick="showPlayerDetails('${p}')" style="font-size:var(--text-sm);font-weight:700;display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;word-break:break-all;">
               ${playerHead(p, 28)}
               <span style="line-height:1">${p}</span>
             </div>
@@ -1189,7 +1295,7 @@
           }
         });
         document.getElementById('pieLegend').style.display = 'flex';
-        document.getElementById('pieLegend').innerHTML = sorted.map(([p,m])=>`<div class="pie-legend-item"><span class="pie-legend-name">${playerHead(p, 24)} ${p}</span><span class="pie-legend-val">${fmtHours(m/60)}</span></div>`).join('');
+        document.getElementById('pieLegend').innerHTML = sorted.map(([p,m])=>`<div class="pie-legend-item" onclick="showPlayerDetails('${p}')" style="cursor:pointer;"><span class="pie-legend-name">${playerHead(p, 24)} ${p}</span><span class="pie-legend-val">${fmtHours(m/60)}</span></div>`).join('');
       }
 
       function buildHourlyForDay(dateStr, animate=true) {
@@ -1280,7 +1386,7 @@
         container.innerHTML = `<div style="font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:var(--space-2);">${label} breakdown</div>` +
           players.map(({p, mins}) => {
             const totalMins = players.reduce((a,b)=>a+b.mins,0);
-            return `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-2);">${playerHead(p, 24)}<span style="font-size:var(--text-xs);color:var(--color-text-muted);width:90px;flex-shrink:0;">${p}</span><div style="flex:1;height:6px;border-radius:3px;background:var(--color-surface-dynamic);overflow:hidden;"><div style="height:100%;width:${Math.round((mins/totalMins)*100)}%;background:${playerColor(p)};"></div></div><span style="font-size:var(--text-xs);font-weight:600;width:48px;text-align:right;">${fmtHours(mins/60)}</span></div>`;
+            return `<div onclick="showPlayerDetails('${p}')" class="breakdown-row">${playerHead(p, 24)}<span style="font-size:var(--text-xs);color:var(--color-text-muted);width:90px;flex-shrink:0;">${p}</span><div style="flex:1;height:6px;border-radius:3px;background:var(--color-surface-dynamic);overflow:hidden;"><div style="height:100%;width:${Math.round((mins/totalMins)*100)}%;background:${playerColor(p)};"></div></div><span style="font-size:var(--text-xs);font-weight:600;width:48px;text-align:right;">${fmtHours(mins/60)}</span></div>`;
           }).join('');
       }
 
@@ -1529,6 +1635,26 @@
         const sd = sessData[name] || {};
         document.getElementById('modalPlayerName').textContent = name;
         document.getElementById('modalPlayerHead').innerHTML = playerHead(name, 32);
+        
+        // Online Status Dot
+        const statusDot = document.getElementById('modalPlayerStatus');
+        const statusTooltip = document.getElementById('modalPlayerStatusTooltip');
+        if (statusDot) {
+          const isOnline = liveState && liveState.playerNames && liveState.playerNames.includes(name);
+          statusDot.className = 'status-dot ' + (isOnline ? 'status-online' : 'status-offline');
+          if (statusTooltip) statusTooltip.textContent = isOnline ? 'Online' : 'Offline';
+          statusDot.onclick = () => { closePlayerModal(); document.getElementById('tabLive').click(); };
+          
+          // If we don't have recent live data, fetch it once to update the dot
+          if (!liveState || (Date.now() - liveState.timestamp > 60000)) {
+            fetch('/api/live').then(r => r.json()).then(data => {
+              liveState = data;
+              const nowOnline = data.playerNames && data.playerNames.includes(name);
+              statusDot.className = 'status-dot ' + (nowOnline ? 'status-online' : 'status-offline');
+              if (statusTooltip) statusTooltip.textContent = nowOnline ? 'Online' : 'Offline';
+            }).catch(() => {});
+          }
+        }
         const totalMinutes = playerTotals[name] || 0;
         const monthly = {};
         for (const [date, players] of Object.entries(playerDailyRaw)) { if (players[name]) { const m = date.substring(0, 7); monthly[m] = (monthly[m] || 0) + players[name]; } }
@@ -1586,20 +1712,40 @@
         const container = document.getElementById('modalIngameStats');
         container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Loading...</div>';
         try {
-          const res = await fetch('/api/player-stats/' + encodeURIComponent(name));
-          if (!res.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
-          const data = await res.json(); if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
-          let distCm = 0; let extracted = {};
+          const [statsRes, advRes] = await Promise.all([
+            fetch('/api/player-stats/' + encodeURIComponent(name)),
+            fetch('/api/player-advancements/' + encodeURIComponent(name)).catch(() => null)
+          ]);
+
+          if (!statsRes.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
+          const data = await statsRes.json();
+          const advData = advRes && advRes.ok ? await advRes.json() : null;
+
+          if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
+          
+          let distCm = 0; 
+          let extracted = {};
           let totalMined = 0;
           let totalUsed = 0;
+          let redstoneUsed = 0;
+
+          const REDSTONE_ITEMS = ['redstone', 'repeater', 'comparator', 'observer', 'piston', 'sticky_piston', 'redstone_torch', 'lever', 'daylight_detector', 'target', 'sculk_sensor', 'dropper', 'dispenser', 'hopper', 'trapped_chest', 'tnt', 'tnt_minecart', 'redstone_lamp', 'redstone_block', 'tripwire_hook', 'sculk_shrieker', 'sculk_catalyst'];
           const ITEM_SUFFIXES = ['_sword', '_pickaxe', '_axe', '_shovel', '_hoe', '_helmet', '_chestplate', '_leggings', '_boots', '_bucket', '_potion', '_stew', '_soup', '_bottle', '_pearl', '_egg', '_rod', '_shears', '_bow', '_crossbow', '_trident', '_shield', '_flint_and_steel', '_spyglass', '_compass', '_clock'];
           const ITEM_NAMES = ['minecraft:apple', 'minecraft:bread', 'minecraft:steak', 'minecraft:cooked_porkchop', 'minecraft:cooked_mutton', 'minecraft:cooked_chicken', 'minecraft:cooked_rabbit', 'minecraft:cooked_cod', 'minecraft:cooked_salmon', 'minecraft:cookie', 'minecraft:pumpkin_pie', 'minecraft:sweet_berries', 'minecraft:glow_berries', 'minecraft:melon_slice', 'minecraft:carrot', 'minecraft:potato', 'minecraft:baked_potato', 'minecraft:poisonous_potato', 'minecraft:dried_kelp', 'minecraft:honey_bottle', 'minecraft:totem_of_undying', 'minecraft:experience_bottle', 'minecraft:ender_pearl', 'minecraft:snowball', 'minecraft:egg', 'minecraft:firework_rocket', 'minecraft:firework_star', 'minecraft:lead', 'minecraft:name_tag', 'minecraft:bone_meal', 'minecraft:ender_eye', 'minecraft:ghast_tear'];
+          
           const isBlockPlacement = (s) => !ITEM_NAMES.includes(s) && !ITEM_SUFFIXES.some(sx => s.endsWith(sx));
+          const isRedstone = (s) => {
+            const id = s.replace('minecraft:', '');
+            return REDSTONE_ITEMS.some(item => id === item || id.includes(item));
+          };
 
           for (const [cat, stats] of Object.entries(data.stats)) {
             for (const [sN, sV] of Object.entries(stats)) {
               if (cat === 'minecraft:mined') totalMined += sV;
-              if (cat === 'minecraft:used' && isBlockPlacement(sN)) totalUsed += sV;
+              if (cat === 'minecraft:used') {
+                if (isBlockPlacement(sN)) totalUsed += sV;
+                if (isRedstone(sN)) redstoneUsed += sV;
+              }
               if (sN.endsWith('_one_cm')) distCm += sV;
               else if (sN === 'minecraft:damage_taken') extracted['damage_taken_hearts'] = Math.floor(sV / 10);
               else if (sN === 'minecraft:damage_dealt') extracted['damage_dealt_hearts'] = Math.floor(sV / 10);
@@ -1614,15 +1760,180 @@
               else if (sN === 'minecraft:ender_dragon') extracted['ender_dragon'] = sV;
             }
           }
+
           if (totalMined > 0) extracted['total_blocks_broken'] = totalMined;
           if (totalUsed > 0) extracted['total_blocks_placed'] = totalUsed;
           if (distCm > 0) extracted['distance_traveled_km'] = Math.floor(distCm / 100000);
-          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { 
+          
+          // Render In-Game Stats Table
+          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.filter(s => !s.id.startsWith('playstyle_')).map(s => { 
             const v = extracted[s.id] || 0; 
             return `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>`; 
           }).join('') + `</div>`;
           container.innerHTML = h;
-        } catch (e) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error.</div>'; }
+
+          // Calculate Playstyle Scores
+          renderPlaystyleChart(name, extracted, redstoneUsed, advData);
+
+        } catch (e) { 
+          console.error("fetchPlayerStats error:", e);
+          container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error loading player stats.</div>'; 
+        }
+      }
+
+      function renderPlaystyleChart(name, extracted, redstoneUsed, advData) {
+        const ctx = document.getElementById('playstyleChart');
+        if (!ctx) return;
+
+        // Briefly show the container to allow Chart.js to calculate dimensions for pre-loading
+        const container = document.getElementById('modalContentPlaystyle');
+        const wasHidden = container.style.display === 'none';
+        if (wasHidden) {
+          container.style.display = 'flex';
+          container.style.visibility = 'hidden';
+          container.style.position = 'absolute';
+        }
+
+        // Cleanup existing chart
+        if (window.playstyleChartObj) {
+          window.playstyleChartObj.destroy();
+        }
+
+        // 1. Explorer Score (Distance + some exploration advancements)
+        const explorerMax = 5000; // 5000km
+        let explorerVal = Math.min(100, (extracted['distance_traveled_km'] || 0) / explorerMax * 100);
+        
+        // 2. Builder Score (Blocks placed + mined)
+        const builderMax = 500000;
+        let builderVal = Math.min(100, ((extracted['total_blocks_placed'] || 0) + (extracted['total_blocks_broken'] || 0) / 4) / builderMax * 100);
+
+        // 3. Fighter Score (Mob kills + damage)
+        const fighterMax = 150000;
+        let fighterVal = Math.min(100, ((extracted['mob_kills'] || 0) + (extracted['damage_dealt_hearts'] || 0) / 10) / fighterMax * 100);
+
+        // 4. Redstoner Score (Redstone components used)
+        const redstoneMax = 7500;
+        let redstoneVal = Math.min(100, redstoneUsed / redstoneMax * 100);
+
+        // Adjust scores based on achievements if available
+        if (advData) {
+          let advExplorerBonus = 0, advBuilderBonus = 0, advFighterBonus = 0, advRedstoneBonus = 0;
+
+          for (const [id, data] of Object.entries(advData)) {
+            if (!data.done) continue;
+            
+            const lowId = id.toLowerCase();
+            // Explorer keywords
+            if (lowId.includes('explore') || lowId.includes('discover') || lowId.includes('travel') || lowId.includes('biome') || lowId.includes('adventure')) {
+              advExplorerBonus += 0.5;
+            }
+            // Builder keywords
+            if (lowId.includes('build') || lowId.includes('construct') || lowId.includes('place') || lowId.includes('craft')) {
+              advBuilderBonus += 0.5;
+            }
+            // Fighter keywords
+            if (lowId.includes('kill') || lowId.includes('slay') || lowId.includes('monster') || lowId.includes('combat') || lowId.includes('boss')) {
+              advFighterBonus += 0.5;
+            }
+            // Redstoner keywords
+            if (lowId.includes('redstone') || lowId.includes('machine') || lowId.includes('circuit') || lowId.includes('automation')) {
+              advRedstoneBonus += 2; // Redstone advancements are rarer
+            }
+
+            // Specific high-value vanilla ones
+            if (id === 'minecraft:story/mine_diamond') advExplorerBonus += 2;
+            if (id === 'minecraft:nether/explore_nether') advExplorerBonus += 5;
+            if (id === 'minecraft:end/kill_dragon') advFighterBonus += 10;
+            if (id === 'minecraft:adventure/kill_all_mobs') advFighterBonus += 15;
+          }
+
+          // Apply bonuses with individual caps (max 30% from achievements)
+          explorerVal += Math.min(30, advExplorerBonus);
+          builderVal += Math.min(30, advBuilderBonus);
+          fighterVal += Math.min(30, advFighterBonus);
+          redstoneVal += Math.min(30, advRedstoneBonus);
+        }
+
+        console.log(`[Playstyle] ${name}:`, {
+          stats: { explorerVal, builderVal, fighterVal, redstoneVal },
+          raw: { distKm: extracted['distance_traveled_km'], totalBlocks: (extracted['total_blocks_placed'] || 0) + (extracted['total_blocks_broken'] || 0)/4, redstoneUsed, mobKills: extracted['mob_kills'] }
+        });
+
+        // Clamp final scores
+        explorerVal = Math.min(100, Math.max(5, explorerVal));
+        builderVal = Math.min(100, Math.max(5, builderVal));
+        fighterVal = Math.min(100, Math.max(5, fighterVal));
+        redstoneVal = Math.min(100, Math.max(5, redstoneVal));
+
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const color = isDark ? 'rgba(79, 152, 163, 0.7)' : 'rgba(1, 105, 111, 0.7)';
+        const borderColor = isDark ? '#4f98a3' : '#01696f';
+        const gridColor = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+        const textColor = isDark ? '#797876' : '#7a7974';
+
+        window.playstyleChartObj = new Chart(ctx, {
+          type: 'radar',
+          data: {
+            labels: ['Explorer', 'Builder', 'Fighter', 'Redstoner'],
+            datasets: [{
+              label: 'Playstyle Profile',
+              data: [explorerVal, builderVal, fighterVal, redstoneVal],
+              fill: true,
+              backgroundColor: color,
+              borderColor: borderColor,
+              pointBackgroundColor: borderColor,
+              pointBorderColor: '#fff',
+              pointHoverBackgroundColor: '#fff',
+              pointHoverBorderColor: borderColor,
+              pointRadius: 6,
+              pointHoverRadius: 8,
+              borderWidth: 2
+            }]
+          },
+          options: {
+            onHover: (e, el) => {
+              e.native.target.style.cursor = el.length ? 'pointer' : 'default';
+            },
+            onClick: (e, el) => {
+              if (el.length > 0) {
+                const index = el[0].index;
+                const label = ['playstyle_explorer', 'playstyle_builder', 'playstyle_fighter', 'playstyle_redstoner'][index];
+                if (label) {
+                  closePlayerModal();
+                  openLeaderboard(label);
+                }
+              }
+            },
+            elements: { line: { tension: 0.1 } },
+            scales: {
+              r: {
+                angleLines: { color: gridColor },
+                grid: { color: gridColor },
+                pointLabels: { color: textColor, font: { size: 16, weight: '700', family: "'Satoshi', sans-serif" } },
+                ticks: { display: false, stepSize: 20 },
+                suggestedMin: 0,
+                suggestedMax: 100
+              }
+            },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: function(context) {
+                    return context.label + ': ' + Math.round(context.raw) + '%';
+                  }
+                }
+              }
+            }
+          }
+        });
+
+        // Restore hidden state after rendering
+        if (wasHidden) {
+          container.style.display = 'none';
+          container.style.visibility = 'visible';
+          container.style.position = 'static';
+        }
       }
 
       // --- Search Implementation ---

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -76,6 +76,14 @@
         display:flex;flex-direction:column;justify-content:space-between;}
       .kpi-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:500;}
       .kpi-value{font-size:var(--text-lg);font-weight:700;letter-spacing:-0.02em;margin-block:auto;padding-block:var(--space-2);}
+      .kpi-value.interactive {
+        cursor: pointer;
+        transition: all var(--transition);
+      }
+      .kpi-value.interactive:hover {
+        color: var(--color-primary);
+        transform: scale(1.02);
+      }
       .kpi-note{font-size:var(--text-xs);color:var(--color-text-faint);}
 
       /* Card */
@@ -93,6 +101,64 @@
         border-color: var(--color-primary);
         transform: translateY(-4px);
         box-shadow: var(--shadow-md);
+      }
+
+      .status-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        display: inline-block;
+        cursor: pointer;
+        transition: all var(--transition);
+        position: relative;
+      }
+      .status-dot:hover { transform: scale(1.25); }
+      .status-online { background-color: #67c23a; box-shadow: 0 0 10px rgba(103, 194, 58, 0.6); }
+      .status-offline { background-color: #f56c6c; box-shadow: 0 0 5px rgba(245, 108, 108, 0.3); }
+
+      .status-tooltip {
+        position: absolute;
+        left: calc(100% + 10px);
+        top: 50%;
+        transform: translateY(-50%) translateX(-10px);
+        background: var(--color-surface-2);
+        border: 1px solid var(--color-border);
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-md);
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        white-space: nowrap;
+        opacity: 0;
+        pointer-events: none;
+        transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+        z-index: 100;
+        box-shadow: var(--shadow-md);
+        color: var(--color-text);
+      }
+      .status-dot:hover .status-tooltip {
+        opacity: 1;
+        transform: translateY(-50%) translateX(0);
+      }
+      .status-tooltip::before {
+        content: '';
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        border: 5px solid transparent;
+        border-right-color: var(--color-border);
+      }
+      .status-tooltip::after {
+        content: '';
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        margin-right: -1px;
+        border: 5px solid transparent;
+        border-right-color: var(--color-surface-2);
       }
 
       /* Heatmap + pie layout */
@@ -157,10 +223,19 @@
       .pie-wrap{position:relative;width:100%;max-width:320px;margin-inline:auto;display:flex;align-items:center;}
       .pie-wrap canvas{width:100%!important;height:auto!important;}
       .pie-legend{display:flex;flex-direction:column;gap:var(--space-2);margin-top:var(--space-3);}
-      .pie-legend-item{display:flex;align-items:center;justify-content:space-between;font-size:var(--text-xs);}
+      .pie-legend-item{display:flex;align-items:center;justify-content:space-between;font-size:var(--text-xs);
+        padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); transition: all var(--transition);}
+      .pie-legend-item[onclick]:hover { background: var(--color-surface-dynamic); transform: translateX(4px); }
       .pie-legend-name{display:flex;align-items:center;gap:var(--space-2);color:var(--color-text-muted);}
       .pie-dot{width:9px;height:9px;border-radius:50%;flex-shrink:0;}
       .pie-legend-val{font-weight:500;color:var(--color-text);}
+
+      .breakdown-row {
+        display:flex; align-items:center; gap:var(--space-3); margin-bottom:var(--space-2);
+        padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm);
+        transition: all var(--transition); cursor: pointer;
+      }
+      .breakdown-row:hover { background: var(--color-surface-dynamic); transform: translateX(4px); }
 
       /* Player head images */
       .player-head{border-radius:var(--radius-sm);image-rendering:pixelated;vertical-align:middle;flex-shrink:0;}
@@ -381,7 +456,7 @@
         flex-direction: column; 
         gap: var(--space-6); 
         overflow-y: auto;
-        overflow-x: hidden;
+        overflow-x: visible;
         height: 100%;
       }
       .modal-player-header { display: flex; align-items: center; gap: var(--space-4); }
@@ -593,7 +668,7 @@
         <div class="card" style="height:fit-content; padding: var(--space-5);">
           <div style="margin-bottom: var(--space-5);">
             <div class="card-title" style="margin-bottom: var(--space-3);">
-              Daily Playtime Calendar <span class="card-subtitle">click a day to see breakdown</span>
+              Playtime Calendar <span class="card-subtitle">click a day to see breakdown</span>
             </div>
             <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-4);">
               <div style="position: relative; width: 240px;">
@@ -662,7 +737,7 @@
 
       <div class="card" id="playerTableCard">
         <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--space-5);">
-          <div class="card-title" style="margin-bottom:0;">Player Breakdown <span class="card-subtitle">total session time</span></div>
+          <div class="card-title" style="margin-bottom:0;">Playtime Breakdown <span class="card-subtitle">total session time</span></div>
           
           <div class="custom-select" id="playerSortContainer" style="margin-bottom: 0; width: 180px;">
             <div class="select-trigger" onclick="togglePlayerSortDropdown()">
@@ -791,26 +866,37 @@
             <div class="modal-player-header">
               <div id="modalPlayerHead"></div>
               <div class="modal-player-name" id="modalPlayerName">PlayerName</div>
+              <div id="modalPlayerStatus" class="status-dot">
+                <div id="modalPlayerStatusTooltip" class="status-tooltip">Offline</div>
+              </div>
             </div>
 
             <div class="modal-tabs">
               <div class="modal-tab active" id="tabModalPlaytime" onclick="switchModalTab('playtime')">Playtime Stats</div>
               <div class="modal-tab" id="tabModalIngame" onclick="switchModalTab('ingame')">In-Game Stats</div>
+              <div class="modal-tab" id="tabModalPlaystyle" onclick="switchModalTab('playstyle')">Playstyle</div>
             </div>
-
             <div id="modalContentPlaytime">
-              <div class="modal-stats-grid" id="modalStats">
-                <!-- Stats dynamic -->
+              <div class="modal-stats-grid" id="modalStats"></div>
+            </div>
+
+            <div id="modalContentIngame" style="display:none; flex-direction:column; gap:var(--space-4);">
+              <div id="modalIngameStats"></div>
+            </div>
+
+            <div id="modalContentPlaystyle" style="display:none; flex-direction:column; gap:var(--space-2); height: 100%;">
+              <div style="text-align: center; margin-top: var(--space-4);">
+                <div style="width: 100%; margin: 0 auto; aspect-ratio: 1/1; position: relative;">
+                  <canvas id="playstyleChart"></canvas>
+                </div>
+              </div>
+              <div style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                <span style="font-weight: 500;">Calculated from latest server logs</span>
               </div>
             </div>
 
-            <div id="modalContentIngame" style="display:none; flex-direction:column;">
-              <div id="modalIngameStats" style="overflow-y:auto; padding-right:var(--space-2);">
-                Loading...
-              </div>
-            </div>
-
-            <div style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
+            <div id="modalFooterGlobal" style="margin-top:var(--space-4); font-size:18px; color:var(--color-text-faint); display:flex; align-items:center; gap:var(--space-3);">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
               <span style="font-weight: 500;">Calculated from latest server logs</span>
             </div>
@@ -886,6 +972,10 @@
       const rankClass = ['rank-1', 'rank-2', 'rank-3'];
       const STAT_CONFIG = [
         { id: 'distance_traveled_km', name: 'Total Distance Traveled', label: 'Distance Traveled', suffix: ' km' },
+        { id: 'playstyle_explorer', name: 'Playstyle: Explorer', label: 'Explorer Score', suffix: '%' },
+        { id: 'playstyle_builder', name: 'Playstyle: Builder', label: 'Builder Score', suffix: '%' },
+        { id: 'playstyle_fighter', name: 'Playstyle: Fighter', label: 'Fighter Score', suffix: '%' },
+        { id: 'playstyle_redstoner', name: 'Playstyle: Redstoner', label: 'Redstoner Score', suffix: '%' },
         { id: 'total_blocks_broken', name: 'Total Blocks Broken', label: 'Blocks Broken', suffix: '' },
         { id: 'total_blocks_placed', name: 'Total Blocks Placed', label: 'Blocks Placed', suffix: '' },
         { id: 'player_kills', name: 'Players Killed', label: 'Players Killed', suffix: '' },
@@ -940,19 +1030,35 @@
       function switchModalTab(tab) {
         const pTab = document.getElementById('tabModalPlaytime');
         const iTab = document.getElementById('tabModalIngame');
+        const sTab = document.getElementById('tabModalPlaystyle');
         const pContent = document.getElementById('modalContentPlaytime');
         const iContent = document.getElementById('modalContentIngame');
+        const sContent = document.getElementById('modalContentPlaystyle');
+        const globalFooter = document.getElementById('modalFooterGlobal');
+
+        pTab.classList.remove('active');
+        iTab.classList.remove('active');
+        sTab.classList.remove('active');
+        pContent.style.display = 'none';
+        iContent.style.display = 'none';
+        sContent.style.display = 'none';
+        if (globalFooter) globalFooter.style.display = 'flex';
 
         if (tab === 'playtime') {
           pTab.classList.add('active');
-          iTab.classList.remove('active');
           pContent.style.display = 'block';
-          iContent.style.display = 'none';
-        } else {
+        } else if (tab === 'ingame') {
           iTab.classList.add('active');
-          pTab.classList.remove('active');
           iContent.style.display = 'flex';
-          pContent.style.display = 'none';
+        } else if (tab === 'playstyle') {
+          sTab.classList.add('active');
+          sContent.style.display = 'flex';
+          if (globalFooter) globalFooter.style.display = 'none';
+          // Force immediate resize update in case it was pre-loaded while hidden
+          if (window.playstyleChartObj) {
+            window.playstyleChartObj.resize();
+            window.playstyleChartObj.update('none');
+          }
         }
       }
 
@@ -989,13 +1095,13 @@
           </div>
           <div class="kpi">
             <div class="kpi-label">Busiest Day</div>
-            <div class="kpi-value">${months[maxDate.getMonth()]} ${maxDate.getDate()}</div>
+            <div class="kpi-value interactive" onclick="jumpToHeatmapDate('${maxDay ? maxDay[0] : ''}')">${months[maxDate.getMonth()]} ${maxDate.getDate()}</div>
             <div class="kpi-note">${maxDay ? maxDay[1].toFixed(1) : 0}h of playtime</div>
           </div>
           ${top3.map(([p,m],i) => `
           <div class="kpi">
             <div class="kpi-label">${rankLabels[i]}</div>
-            <div class="kpi-value" style="font-size:var(--text-sm);font-weight:700;display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;word-break:break-all;">
+            <div class="kpi-value interactive" onclick="showPlayerDetails('${p}')" style="font-size:var(--text-sm);font-weight:700;display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;word-break:break-all;">
               ${playerHead(p, 28)}
               <span style="line-height:1">${p}</span>
             </div>
@@ -1189,7 +1295,7 @@
           }
         });
         document.getElementById('pieLegend').style.display = 'flex';
-        document.getElementById('pieLegend').innerHTML = sorted.map(([p,m])=>`<div class="pie-legend-item"><span class="pie-legend-name">${playerHead(p, 24)} ${p}</span><span class="pie-legend-val">${fmtHours(m/60)}</span></div>`).join('');
+        document.getElementById('pieLegend').innerHTML = sorted.map(([p,m])=>`<div class="pie-legend-item" onclick="showPlayerDetails('${p}')" style="cursor:pointer;"><span class="pie-legend-name">${playerHead(p, 24)} ${p}</span><span class="pie-legend-val">${fmtHours(m/60)}</span></div>`).join('');
       }
 
       function buildHourlyForDay(dateStr, animate=true) {
@@ -1280,7 +1386,7 @@
         container.innerHTML = `<div style="font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:var(--space-2);">${label} breakdown</div>` +
           players.map(({p, mins}) => {
             const totalMins = players.reduce((a,b)=>a+b.mins,0);
-            return `<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-2);">${playerHead(p, 24)}<span style="font-size:var(--text-xs);color:var(--color-text-muted);width:90px;flex-shrink:0;">${p}</span><div style="flex:1;height:6px;border-radius:3px;background:var(--color-surface-dynamic);overflow:hidden;"><div style="height:100%;width:${Math.round((mins/totalMins)*100)}%;background:${playerColor(p)};"></div></div><span style="font-size:var(--text-xs);font-weight:600;width:48px;text-align:right;">${fmtHours(mins/60)}</span></div>`;
+            return `<div onclick="showPlayerDetails('${p}')" class="breakdown-row">${playerHead(p, 24)}<span style="font-size:var(--text-xs);color:var(--color-text-muted);width:90px;flex-shrink:0;">${p}</span><div style="flex:1;height:6px;border-radius:3px;background:var(--color-surface-dynamic);overflow:hidden;"><div style="height:100%;width:${Math.round((mins/totalMins)*100)}%;background:${playerColor(p)};"></div></div><span style="font-size:var(--text-xs);font-weight:600;width:48px;text-align:right;">${fmtHours(mins/60)}</span></div>`;
           }).join('');
       }
 
@@ -1529,6 +1635,26 @@
         const sd = sessData[name] || {};
         document.getElementById('modalPlayerName').textContent = name;
         document.getElementById('modalPlayerHead').innerHTML = playerHead(name, 32);
+        
+        // Online Status Dot
+        const statusDot = document.getElementById('modalPlayerStatus');
+        const statusTooltip = document.getElementById('modalPlayerStatusTooltip');
+        if (statusDot) {
+          const isOnline = liveState && liveState.playerNames && liveState.playerNames.includes(name);
+          statusDot.className = 'status-dot ' + (isOnline ? 'status-online' : 'status-offline');
+          if (statusTooltip) statusTooltip.textContent = isOnline ? 'Online' : 'Offline';
+          statusDot.onclick = () => { closePlayerModal(); document.getElementById('tabLive').click(); };
+          
+          // If we don't have recent live data, fetch it once to update the dot
+          if (!liveState || (Date.now() - liveState.timestamp > 60000)) {
+            fetch('/api/live').then(r => r.json()).then(data => {
+              liveState = data;
+              const nowOnline = data.playerNames && data.playerNames.includes(name);
+              statusDot.className = 'status-dot ' + (nowOnline ? 'status-online' : 'status-offline');
+              if (statusTooltip) statusTooltip.textContent = nowOnline ? 'Online' : 'Offline';
+            }).catch(() => {});
+          }
+        }
         const totalMinutes = playerTotals[name] || 0;
         const monthly = {};
         for (const [date, players] of Object.entries(playerDailyRaw)) { if (players[name]) { const m = date.substring(0, 7); monthly[m] = (monthly[m] || 0) + players[name]; } }
@@ -1586,20 +1712,40 @@
         const container = document.getElementById('modalIngameStats');
         container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Loading...</div>';
         try {
-          const res = await fetch('/api/player-stats/' + encodeURIComponent(name));
-          if (!res.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
-          const data = await res.json(); if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
-          let distCm = 0; let extracted = {};
+          const [statsRes, advRes] = await Promise.all([
+            fetch('/api/player-stats/' + encodeURIComponent(name)),
+            fetch('/api/player-advancements/' + encodeURIComponent(name)).catch(() => null)
+          ]);
+
+          if (!statsRes.ok) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats found.</div>'; return; }
+          const data = await statsRes.json();
+          const advData = advRes && advRes.ok ? await advRes.json() : null;
+
+          if (!data.stats) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">No stats.</div>'; return; }
+          
+          let distCm = 0; 
+          let extracted = {};
           let totalMined = 0;
           let totalUsed = 0;
+          let redstoneUsed = 0;
+
+          const REDSTONE_ITEMS = ['redstone', 'repeater', 'comparator', 'observer', 'piston', 'sticky_piston', 'redstone_torch', 'lever', 'daylight_detector', 'target', 'sculk_sensor', 'dropper', 'dispenser', 'hopper', 'trapped_chest', 'tnt', 'tnt_minecart', 'redstone_lamp', 'redstone_block', 'tripwire_hook', 'sculk_shrieker', 'sculk_catalyst'];
           const ITEM_SUFFIXES = ['_sword', '_pickaxe', '_axe', '_shovel', '_hoe', '_helmet', '_chestplate', '_leggings', '_boots', '_bucket', '_potion', '_stew', '_soup', '_bottle', '_pearl', '_egg', '_rod', '_shears', '_bow', '_crossbow', '_trident', '_shield', '_flint_and_steel', '_spyglass', '_compass', '_clock'];
           const ITEM_NAMES = ['minecraft:apple', 'minecraft:bread', 'minecraft:steak', 'minecraft:cooked_porkchop', 'minecraft:cooked_mutton', 'minecraft:cooked_chicken', 'minecraft:cooked_rabbit', 'minecraft:cooked_cod', 'minecraft:cooked_salmon', 'minecraft:cookie', 'minecraft:pumpkin_pie', 'minecraft:sweet_berries', 'minecraft:glow_berries', 'minecraft:melon_slice', 'minecraft:carrot', 'minecraft:potato', 'minecraft:baked_potato', 'minecraft:poisonous_potato', 'minecraft:dried_kelp', 'minecraft:honey_bottle', 'minecraft:totem_of_undying', 'minecraft:experience_bottle', 'minecraft:ender_pearl', 'minecraft:snowball', 'minecraft:egg', 'minecraft:firework_rocket', 'minecraft:firework_star', 'minecraft:lead', 'minecraft:name_tag', 'minecraft:bone_meal', 'minecraft:ender_eye', 'minecraft:ghast_tear'];
+          
           const isBlockPlacement = (s) => !ITEM_NAMES.includes(s) && !ITEM_SUFFIXES.some(sx => s.endsWith(sx));
+          const isRedstone = (s) => {
+            const id = s.replace('minecraft:', '');
+            return REDSTONE_ITEMS.some(item => id === item || id.includes(item));
+          };
 
           for (const [cat, stats] of Object.entries(data.stats)) {
             for (const [sN, sV] of Object.entries(stats)) {
               if (cat === 'minecraft:mined') totalMined += sV;
-              if (cat === 'minecraft:used' && isBlockPlacement(sN)) totalUsed += sV;
+              if (cat === 'minecraft:used') {
+                if (isBlockPlacement(sN)) totalUsed += sV;
+                if (isRedstone(sN)) redstoneUsed += sV;
+              }
               if (sN.endsWith('_one_cm')) distCm += sV;
               else if (sN === 'minecraft:damage_taken') extracted['damage_taken_hearts'] = Math.floor(sV / 10);
               else if (sN === 'minecraft:damage_dealt') extracted['damage_dealt_hearts'] = Math.floor(sV / 10);
@@ -1614,15 +1760,180 @@
               else if (sN === 'minecraft:ender_dragon') extracted['ender_dragon'] = sV;
             }
           }
+
           if (totalMined > 0) extracted['total_blocks_broken'] = totalMined;
           if (totalUsed > 0) extracted['total_blocks_placed'] = totalUsed;
           if (distCm > 0) extracted['distance_traveled_km'] = Math.floor(distCm / 100000);
-          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.map(s => { 
+          
+          // Render In-Game Stats Table
+          let h = `<div class="modal-stats-grid">` + STAT_CONFIG.filter(s => !s.id.startsWith('playstyle_')).map(s => { 
             const v = extracted[s.id] || 0; 
             return `<div class="stat-card interactive" onclick="openLeaderboard('${s.id}')"><div class="stat-label">${s.label}</div><div class="stat-value">${v.toLocaleString()}${s.suffix}</div></div>`; 
           }).join('') + `</div>`;
           container.innerHTML = h;
-        } catch (e) { container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error.</div>'; }
+
+          // Calculate Playstyle Scores
+          renderPlaystyleChart(name, extracted, redstoneUsed, advData);
+
+        } catch (e) { 
+          console.error("fetchPlayerStats error:", e);
+          container.innerHTML = '<div style="text-align:center;color:var(--color-text-faint);">Error loading player stats.</div>'; 
+        }
+      }
+
+      function renderPlaystyleChart(name, extracted, redstoneUsed, advData) {
+        const ctx = document.getElementById('playstyleChart');
+        if (!ctx) return;
+
+        // Briefly show the container to allow Chart.js to calculate dimensions for pre-loading
+        const container = document.getElementById('modalContentPlaystyle');
+        const wasHidden = container.style.display === 'none';
+        if (wasHidden) {
+          container.style.display = 'flex';
+          container.style.visibility = 'hidden';
+          container.style.position = 'absolute';
+        }
+
+        // Cleanup existing chart
+        if (window.playstyleChartObj) {
+          window.playstyleChartObj.destroy();
+        }
+
+        // 1. Explorer Score (Distance + some exploration advancements)
+        const explorerMax = 5000; // 5000km
+        let explorerVal = Math.min(100, (extracted['distance_traveled_km'] || 0) / explorerMax * 100);
+        
+        // 2. Builder Score (Blocks placed + mined)
+        const builderMax = 500000;
+        let builderVal = Math.min(100, ((extracted['total_blocks_placed'] || 0) + (extracted['total_blocks_broken'] || 0) / 4) / builderMax * 100);
+
+        // 3. Fighter Score (Mob kills + damage)
+        const fighterMax = 150000;
+        let fighterVal = Math.min(100, ((extracted['mob_kills'] || 0) + (extracted['damage_dealt_hearts'] || 0) / 10) / fighterMax * 100);
+
+        // 4. Redstoner Score (Redstone components used)
+        const redstoneMax = 7500;
+        let redstoneVal = Math.min(100, redstoneUsed / redstoneMax * 100);
+
+        // Adjust scores based on achievements if available
+        if (advData) {
+          let advExplorerBonus = 0, advBuilderBonus = 0, advFighterBonus = 0, advRedstoneBonus = 0;
+
+          for (const [id, data] of Object.entries(advData)) {
+            if (!data.done) continue;
+            
+            const lowId = id.toLowerCase();
+            // Explorer keywords
+            if (lowId.includes('explore') || lowId.includes('discover') || lowId.includes('travel') || lowId.includes('biome') || lowId.includes('adventure')) {
+              advExplorerBonus += 0.5;
+            }
+            // Builder keywords
+            if (lowId.includes('build') || lowId.includes('construct') || lowId.includes('place') || lowId.includes('craft')) {
+              advBuilderBonus += 0.5;
+            }
+            // Fighter keywords
+            if (lowId.includes('kill') || lowId.includes('slay') || lowId.includes('monster') || lowId.includes('combat') || lowId.includes('boss')) {
+              advFighterBonus += 0.5;
+            }
+            // Redstoner keywords
+            if (lowId.includes('redstone') || lowId.includes('machine') || lowId.includes('circuit') || lowId.includes('automation')) {
+              advRedstoneBonus += 2; // Redstone advancements are rarer
+            }
+
+            // Specific high-value vanilla ones
+            if (id === 'minecraft:story/mine_diamond') advExplorerBonus += 2;
+            if (id === 'minecraft:nether/explore_nether') advExplorerBonus += 5;
+            if (id === 'minecraft:end/kill_dragon') advFighterBonus += 10;
+            if (id === 'minecraft:adventure/kill_all_mobs') advFighterBonus += 15;
+          }
+
+          // Apply bonuses with individual caps (max 30% from achievements)
+          explorerVal += Math.min(30, advExplorerBonus);
+          builderVal += Math.min(30, advBuilderBonus);
+          fighterVal += Math.min(30, advFighterBonus);
+          redstoneVal += Math.min(30, advRedstoneBonus);
+        }
+
+        console.log(`[Playstyle] ${name}:`, {
+          stats: { explorerVal, builderVal, fighterVal, redstoneVal },
+          raw: { distKm: extracted['distance_traveled_km'], totalBlocks: (extracted['total_blocks_placed'] || 0) + (extracted['total_blocks_broken'] || 0)/4, redstoneUsed, mobKills: extracted['mob_kills'] }
+        });
+
+        // Clamp final scores
+        explorerVal = Math.min(100, Math.max(5, explorerVal));
+        builderVal = Math.min(100, Math.max(5, builderVal));
+        fighterVal = Math.min(100, Math.max(5, fighterVal));
+        redstoneVal = Math.min(100, Math.max(5, redstoneVal));
+
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const color = isDark ? 'rgba(79, 152, 163, 0.7)' : 'rgba(1, 105, 111, 0.7)';
+        const borderColor = isDark ? '#4f98a3' : '#01696f';
+        const gridColor = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+        const textColor = isDark ? '#797876' : '#7a7974';
+
+        window.playstyleChartObj = new Chart(ctx, {
+          type: 'radar',
+          data: {
+            labels: ['Explorer', 'Builder', 'Fighter', 'Redstoner'],
+            datasets: [{
+              label: 'Playstyle Profile',
+              data: [explorerVal, builderVal, fighterVal, redstoneVal],
+              fill: true,
+              backgroundColor: color,
+              borderColor: borderColor,
+              pointBackgroundColor: borderColor,
+              pointBorderColor: '#fff',
+              pointHoverBackgroundColor: '#fff',
+              pointHoverBorderColor: borderColor,
+              pointRadius: 6,
+              pointHoverRadius: 8,
+              borderWidth: 2
+            }]
+          },
+          options: {
+            onHover: (e, el) => {
+              e.native.target.style.cursor = el.length ? 'pointer' : 'default';
+            },
+            onClick: (e, el) => {
+              if (el.length > 0) {
+                const index = el[0].index;
+                const label = ['playstyle_explorer', 'playstyle_builder', 'playstyle_fighter', 'playstyle_redstoner'][index];
+                if (label) {
+                  closePlayerModal();
+                  openLeaderboard(label);
+                }
+              }
+            },
+            elements: { line: { tension: 0.1 } },
+            scales: {
+              r: {
+                angleLines: { color: gridColor },
+                grid: { color: gridColor },
+                pointLabels: { color: textColor, font: { size: 16, weight: '700', family: "'Satoshi', sans-serif" } },
+                ticks: { display: false, stepSize: 20 },
+                suggestedMin: 0,
+                suggestedMax: 100
+              }
+            },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: function(context) {
+                    return context.label + ': ' + Math.round(context.raw) + '%';
+                  }
+                }
+              }
+            }
+          }
+        });
+
+        // Restore hidden state after rendering
+        if (wasHidden) {
+          container.style.display = 'none';
+          container.style.visibility = 'visible';
+          container.style.position = 'static';
+        }
       }
 
       // --- Search Implementation ---


### PR DESCRIPTION
### Summary
This PR synchronizes playstyle score calculations between aliased accounts and significantly enhances the dashboard's interactivity and navigation.

### Changes
- **Backend Refactor**: Moved playstyle calculations to a global post-aggregation step in `StatsAggregator.java`. This ensures that players with multiple UUIDs (aliased) have their raw stats summed *before* percentages are calculated, preventing impossible values (e.g., >100%).
- **UI Interactivity**:
  - Added real-time online status indicator (dot) to player modals with custom arrow tooltips.
  - Linked the status dot to the **Live** tab.
  - Made the "Busiest Day" KPI clickable to jump to that day in the heatmap.
  - Added modal navigation links to all player names in the pie chart legend and hourly breakdowns.
  - Refined hover effects across all interactive elements for better usability.
- **Styling**: Standardized card titles to Title Case ("Playtime Calendar", "Playtime Breakdown").
- **Bug Fix**: Filtered out redundant playstyle stat cards from the in-game stats tab to avoid clutter.