### PR TITLE
feat: Server Events & Live Leaderboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dashboard-config.json
 # OS artifacts
 .DS_Store
 Thumbs.db
+
+# Build artifacts
+backend/src/main/resources/web/

--- a/backend/src/main/java/com/playtime/dashboard/FabricDashboardMod.java
+++ b/backend/src/main/java/com/playtime/dashboard/FabricDashboardMod.java
@@ -1,11 +1,15 @@
 package com.playtime.dashboard;
 
+import com.playtime.dashboard.commands.DashboardCommand;
+import com.playtime.dashboard.config.DashboardConfig;
+import com.playtime.dashboard.events.EventManager;
+import com.playtime.dashboard.web.DashboardWebServer;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.playtime.dashboard.web.DashboardWebServer;
-import com.playtime.dashboard.config.DashboardConfig;
 
 /**
  * Entry point for the Fabric Activity Dashboard mod.
@@ -15,21 +19,36 @@ import com.playtime.dashboard.config.DashboardConfig;
 public class FabricDashboardMod implements ModInitializer {
     public static final Logger LOGGER = LoggerFactory.getLogger("fabric-dashboard");
     private DashboardWebServer webServer;
+    private int tickCounter = 0;
 
     @Override
     public void onInitialize() {
         LOGGER.info("Initializing Fabric Activity Dashboard...");
         
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+            DashboardCommand.register(dispatcher);
+        });
+
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             DashboardConfig.load();
+            EventManager.getInstance().init(server);
             webServer = new DashboardWebServer(server);
             webServer.start();
+        });
+
+        ServerTickEvents.END_SERVER_TICK.register(server -> {
+            tickCounter++;
+            if (tickCounter >= 200) { // Every 10 seconds
+                EventManager.getInstance().tick();
+                tickCounter = 0;
+            }
         });
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
             if (webServer != null) {
                 webServer.stop();
             }
+            EventManager.getInstance().save();
         });
     }
 }

--- a/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
+++ b/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
@@ -1,0 +1,101 @@
+package com.playtime.dashboard.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.playtime.dashboard.events.EventManager;
+import com.playtime.dashboard.events.ServerEvent;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+public class DashboardCommand {
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(CommandManager.literal("dashboard")
+            .then(CommandManager.literal("event")
+                .requires(source -> source.hasPermissionLevel(2))
+                .then(CommandManager.literal("create")
+                    .then(CommandManager.argument("type", StringArgumentType.word())
+                        .suggests((context, builder) -> {
+                            builder.suggest("playtime");
+                            builder.suggest("blocks_placed");
+                            builder.suggest("blocks_mined");
+                            builder.suggest("mob_kills");
+                            return builder.buildFuture();
+                        })
+                        .then(CommandManager.argument("duration_hours", IntegerArgumentType.integer(1))
+                            .then(CommandManager.argument("title", StringArgumentType.greedyString())
+                                .executes(context -> {
+                                    String type = StringArgumentType.getString(context, "type");
+                                    int hours = IntegerArgumentType.getInteger(context, "duration_hours");
+                                    String title = StringArgumentType.getString(context, "title");
+                                    
+                                    EventManager.getInstance().startEvent(title, type, hours);
+                                    context.getSource().sendFeedback(() -> Text.literal("§aEvent created: " + title), true);
+                                    return 1;
+                                })
+                            )
+                        )
+                    )
+                )
+                .then(CommandManager.literal("stop")
+                    .executes(context -> {
+                        EventManager.getInstance().stopEvent();
+                        context.getSource().sendFeedback(() -> Text.literal("§cEvent stopped."), true);
+                        return 1;
+                    })
+                )
+                .then(CommandManager.literal("status")
+                    .executes(context -> {
+                        ServerEvent active = EventManager.getInstance().getActiveEvent();
+                        if (active == null) {
+                            context.getSource().sendFeedback(() -> Text.literal("§eNo active event."), false);
+                        } else {
+                            context.getSource().sendFeedback(() -> Text.literal("§6Active Event: §f" + active.title), false);
+                            context.getSource().sendFeedback(() -> Text.literal("§6Type: §f" + active.type), false);
+                            long remaining = (active.endTime - System.currentTimeMillis()) / 1000;
+                            context.getSource().sendFeedback(() -> Text.literal("§6Remaining: §f" + (remaining / 60) + "m " + (remaining % 60) + "s"), false);
+                        }
+                        return 1;
+                    })
+                )
+                .then(CommandManager.literal("clearpoints")
+                    .then(CommandManager.literal("all")
+                        .executes(context -> {
+                            EventManager.getInstance().clearAllPoints(0);
+                            context.getSource().sendFeedback(() -> Text.literal("§aCleared all points for all players."), true);
+                            return 1;
+                        })
+                        .then(CommandManager.argument("amount", IntegerArgumentType.integer(1))
+                            .executes(context -> {
+                                int amount = IntegerArgumentType.getInteger(context, "amount");
+                                EventManager.getInstance().clearAllPoints(amount);
+                                context.getSource().sendFeedback(() -> Text.literal("§aRemoved " + amount + " points from all players."), true);
+                                return 1;
+                            })
+                        )
+                    )
+                    .then(CommandManager.literal("user")
+                        .then(CommandManager.argument("player", StringArgumentType.word())
+                            .executes(context -> {
+                                String player = StringArgumentType.getString(context, "player");
+                                EventManager.getInstance().clearUserPoints(player, 0);
+                                context.getSource().sendFeedback(() -> Text.literal("§aCleared all points for " + player), true);
+                                return 1;
+                            })
+                            .then(CommandManager.argument("amount", IntegerArgumentType.integer(1))
+                                .executes(context -> {
+                                    String player = StringArgumentType.getString(context, "player");
+                                    int amount = IntegerArgumentType.getInteger(context, "amount");
+                                    EventManager.getInstance().clearUserPoints(player, amount);
+                                    context.getSource().sendFeedback(() -> Text.literal("§aRemoved " + amount + " points from " + player), true);
+                                    return 1;
+                                })
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
@@ -1,0 +1,427 @@
+package com.playtime.dashboard.events;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.playtime.dashboard.FabricDashboardMod;
+import com.playtime.dashboard.config.DashboardConfig;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.scoreboard.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.StatType;
+import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
+import net.minecraft.scoreboard.number.*;
+import net.minecraft.util.Identifier;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class EventManager {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static EventManager instance;
+    private final File eventsFile;
+    private MinecraftServer server;
+    
+    private ServerEvent activeEvent;
+    private Map<String, Integer> allTimePoints = new HashMap<>();
+
+    private EventManager() {
+        this.eventsFile = new File(FabricLoader.getInstance().getGameDir().toFile(), "dashboard_events.json");
+        load();
+    }
+
+    public static EventManager getInstance() {
+        if (instance == null) {
+            instance = new EventManager();
+        }
+        return instance;
+    }
+
+    public void init(MinecraftServer server) {
+        this.server = server;
+        updateScoreboard();
+    }
+
+    public ServerEvent getActiveEvent() {
+        return activeEvent;
+    }
+
+    public Map<String, Integer> getAllTimePoints() {
+        return allTimePoints;
+    }
+
+    public Map<String, String> resolveNames(Set<String> uuids) {
+        Map<String, String> resolved = new HashMap<>();
+        for (String uuidStr : uuids) {
+            resolved.put(uuidStr, getPlayerName(uuidStr));
+        }
+        return resolved;
+    }
+
+    public void startEvent(String title, String type, int durationHours) {
+        if (activeEvent != null) {
+            stopEvent();
+        }
+
+        long now = System.currentTimeMillis();
+        activeEvent = new ServerEvent(
+            UUID.randomUUID().toString(),
+            title,
+            type,
+            now,
+            now + (long) durationHours * 60 * 60 * 1000
+        );
+
+        // Take snapshot of initial stats for all known players
+        takeStatsSnapshot();
+        save();
+        updateScoreboard();
+        
+        server.getPlayerManager().broadcast(Text.literal("§6[Event] §aNew event started: §l" + title), false);
+        server.getPlayerManager().broadcast(Text.literal("§6[Event] §eGoal: " + type.replace("_", " ") + " for " + durationHours + " hours!"), false);
+    }
+
+    public void stopEvent() {
+        if (activeEvent == null) return;
+
+        updateScores(); // Final update
+        distributePoints();
+        
+        server.getPlayerManager().broadcast(Text.literal("§6[Event] §cEvent ended: §l" + activeEvent.title), false);
+        
+        // Remove scoreboard objective
+        Scoreboard scoreboard = server.getScoreboard();
+        ScoreboardObjective objective = scoreboard.getNullableObjective("event_lb");
+        if (objective != null) {
+            scoreboard.removeObjective(objective);
+        }
+
+        activeEvent = null;
+        save();
+    }
+
+    private void takeStatsSnapshot() {
+        Path statsDir = getStatsPath();
+        
+        // 1. Snapshot disk stats
+        File[] files = statsDir.toFile().listFiles((d, n) -> n.endsWith(".json"));
+        if (files != null) {
+            for (File statFile : files) {
+                String uuidStr = statFile.getName().replace(".json", "");
+                int value = getStatValueFromDisk(statFile, activeEvent.type);
+                activeEvent.initialStats.put(uuidStr, value);
+            }
+        }
+
+        // 2. Overwrite with live stats for online players (more accurate)
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            String uuidStr = player.getUuid().toString();
+            activeEvent.initialStats.put(uuidStr, getStatValueFromPlayer(player, activeEvent.type));
+        }
+    }
+
+    private Path getStatsPath() {
+        return FabricLoader.getInstance().getGameDir()
+                .resolve(DashboardConfig.get().stats_world_name)
+                .resolve("stats");
+    }
+
+    public void tick() {
+        if (activeEvent == null) return;
+
+        if (System.currentTimeMillis() > activeEvent.endTime) {
+            stopEvent();
+            return;
+        }
+
+        updateScores();
+    }
+
+    private void updateScores() {
+        if (activeEvent == null) return;
+
+        // 1. Update from disk (Offline players and baseline)
+        Path statsDir = getStatsPath();
+        File[] files = statsDir.toFile().listFiles((d, n) -> n.endsWith(".json"));
+        if (files != null) {
+            for (File statFile : files) {
+                String uuidStr = statFile.getName().replace(".json", "");
+                int currentValue = getStatValueFromDisk(statFile, activeEvent.type);
+                updatePlayerScore(uuidStr, currentValue);
+            }
+        }
+
+        // 2. Update from online players (Override disk with live data)
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            String uuidStr = player.getUuid().toString();
+            int currentValue = getStatValueFromPlayer(player, activeEvent.type);
+            updatePlayerScore(uuidStr, currentValue);
+        }
+        
+        updateScoreboard();
+    }
+
+    private void updatePlayerScore(String uuidStr, int currentValue) {
+        if (!activeEvent.initialStats.containsKey(uuidStr)) {
+            activeEvent.initialStats.put(uuidStr, currentValue);
+        }
+        
+        int initialValue = activeEvent.initialStats.get(uuidStr);
+        int score = currentValue - initialValue;
+        
+        // Convert playtime ticks to seconds for better readability
+        if (activeEvent.type.equals("playtime")) {
+            score = score / 20;
+        }
+        
+        if (score > 0) {
+            activeEvent.currentScores.put(uuidStr, score);
+        }
+    }
+
+    private int getStatValueFromPlayer(ServerPlayerEntity player, String type) {
+        switch (type) {
+            case "playtime":
+                // Try both play_time and play_one_minute identifiers
+                int pt = player.getStatHandler().getStat(Stats.CUSTOM, Registries.CUSTOM_STAT.get(Identifier.of("minecraft", "play_time")));
+                if (pt == 0) pt = player.getStatHandler().getStat(Stats.CUSTOM, Registries.CUSTOM_STAT.get(Identifier.of("minecraft", "play_one_minute")));
+                return pt;
+            case "mob_kills":
+                return player.getStatHandler().getStat(Stats.CUSTOM, Registries.CUSTOM_STAT.get(Identifier.of("minecraft", "mob_kills")));
+            case "blocks_placed":
+                return sumCategoryFromPlayer(player, Stats.USED, Registries.ITEM, true);
+            case "blocks_mined":
+                return sumCategoryFromPlayer(player, Stats.MINED, Registries.BLOCK, false);
+            default:
+                return 0;
+        }
+    }
+
+    private <T> int sumCategoryFromPlayer(ServerPlayerEntity player, StatType<T> category, net.minecraft.registry.Registry<T> registry, boolean checkBlocks) {
+        int sum = 0;
+        for (T entry : registry) {
+            int value = player.getStatHandler().getStat(category, entry);
+            if (value > 0) {
+                if (checkBlocks) {
+                    if (isBlockHeuristic(registry.getId(entry).toString())) {
+                        sum += value;
+                    }
+                } else {
+                    sum += value;
+                }
+            }
+        }
+        return sum;
+    }
+
+    private int getStatValueFromDisk(File statFile, String type) {
+        try (FileReader reader = new FileReader(statFile)) {
+            JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+            if (!root.has("stats")) return 0;
+            JsonObject stats = root.getAsJsonObject("stats");
+
+            switch (type) {
+                case "playtime":
+                    int pt = getNestedInt(stats, "minecraft:custom", "minecraft:play_time");
+                    if (pt == 0) pt = getNestedInt(stats, "minecraft:custom", "minecraft:play_one_minute");
+                    return pt;
+                case "mob_kills":
+                    return getNestedInt(stats, "minecraft:custom", "minecraft:mob_kills");
+                case "blocks_placed":
+                    return sumCategory(stats, "minecraft:used", true); // heuristic: used blocks
+                case "blocks_mined":
+                    return sumCategory(stats, "minecraft:mined", false);
+                default:
+                    return 0;
+            }
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private int getNestedInt(JsonObject stats, String category, String stat) {
+        if (stats.has(category)) {
+            JsonObject catObj = stats.getAsJsonObject(category);
+            if (catObj.has(stat)) {
+                return catObj.get(stat).getAsInt();
+            }
+        }
+        return 0;
+    }
+
+    private int sumCategory(JsonObject stats, String category, boolean checkBlocks) {
+        if (!stats.has(category)) return 0;
+        JsonObject catObj = stats.getAsJsonObject(category);
+        int sum = 0;
+        for (String key : catObj.keySet()) {
+            // Basic heuristic for blocks: doesn't end with common item suffixes
+            if (checkBlocks) {
+                if (isBlockHeuristic(key)) sum += catObj.get(key).getAsInt();
+            } else {
+                sum += catObj.get(key).getAsInt();
+            }
+        }
+        return sum;
+    }
+
+    private boolean isBlockHeuristic(String key) {
+        String k = key.replace("minecraft:", "");
+        return !k.endsWith("_sword") && !k.endsWith("_pickaxe") && !k.endsWith("_axe") && 
+               !k.endsWith("_shovel") && !k.endsWith("_hoe") && !k.endsWith("_helmet") &&
+               !k.endsWith("_chestplate") && !k.endsWith("_leggings") && !k.endsWith("_boots") &&
+               !k.equals("apple") && !k.equals("bread") && !k.equals("stick");
+    }
+
+    private void updateScoreboard() {
+        if (server == null || activeEvent == null) return;
+
+        Scoreboard scoreboard = server.getScoreboard();
+        ScoreboardObjective objective = scoreboard.getNullableObjective("event_lb");
+        
+        if (objective == null) {
+            objective = scoreboard.addObjective("event_lb", ScoreboardCriterion.DUMMY, 
+                Text.literal("§6§l" + activeEvent.title), ScoreboardCriterion.RenderType.INTEGER, false, null);
+            scoreboard.setObjectiveSlot(ScoreboardDisplaySlot.SIDEBAR, objective);
+        }
+
+        final ScoreboardObjective finalObjective = objective;
+        activeEvent.currentScores.entrySet().stream()
+            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            .limit(15)
+            .forEach(entry -> {
+                String uuidStr = entry.getKey();
+                int val = entry.getValue();
+                String name = getPlayerName(uuidStr);
+                
+                ScoreHolder holder = ScoreHolder.fromName(name);
+                var score = scoreboard.getOrCreateScore(holder, finalObjective);
+                
+                if (activeEvent.type.equals("playtime")) {
+                    String formattedTime = formatTime(val);
+                    score.setDisplayText(Text.literal("§f" + name + " §e" + formattedTime));
+                    // Try to hide the score number if the class exists, otherwise it just shows alongside
+                    try {
+                        score.setNumberFormat(BlankNumberFormat.INSTANCE);
+                    } catch (Throwable ignored) {}
+                } else {
+                    score.setDisplayText(null); // Reset to default
+                    score.setNumberFormat(null);
+                }
+                
+                score.setScore(val);
+            });
+    }
+
+    private String formatTime(int seconds) {
+        int d = seconds / 86400;
+        int h = (seconds % 86400) / 3600;
+        int m = (seconds % 3600) / 60;
+        int s = seconds % 60;
+        
+        StringBuilder sb = new StringBuilder();
+        if (d > 0) sb.append(d).append("d ");
+        if (h > 0 || d > 0) sb.append(h).append("h ");
+        if (m > 0 || h > 0 || d > 0) sb.append(m).append("m ");
+        sb.append(s).append("s");
+        return sb.toString();
+    }
+
+    public void clearAllPoints(int amount) {
+        if (amount <= 0) {
+            allTimePoints.clear();
+        } else {
+            allTimePoints.replaceAll((uuid, points) -> Math.max(0, points - amount));
+        }
+        save();
+    }
+
+    public void clearUserPoints(String playerOrUuid, int amount) {
+        String uuidStr = playerOrUuid;
+        // Try to find UUID if it's a name
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (player.getGameProfile().getName().equalsIgnoreCase(playerOrUuid)) {
+                uuidStr = player.getUuid().toString();
+                break;
+            }
+        }
+        
+        if (amount <= 0) {
+            allTimePoints.remove(uuidStr);
+        } else {
+            allTimePoints.computeIfPresent(uuidStr, (k, v) -> Math.max(0, v - amount));
+        }
+        save();
+    }
+
+    private String getPlayerName(String uuidStr) {
+        try {
+            UUID uuid = UUID.fromString(uuidStr);
+            ServerPlayerEntity player = server.getPlayerManager().getPlayer(uuid);
+            if (player != null) return player.getGameProfile().getName();
+            
+            // Fallback to usercache
+            return server.getUserCache().getByUuid(uuid).map(p -> p.getName()).orElse(uuidStr);
+        } catch (Exception e) {
+            return uuidStr;
+        }
+    }
+
+    private void distributePoints() {
+        if (activeEvent == null) return;
+
+        List<Map.Entry<String, Integer>> sorted = activeEvent.currentScores.entrySet().stream()
+            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            .collect(Collectors.toList());
+
+        for (int i = 0; i < sorted.size(); i++) {
+            String uuid = sorted.get(i).getKey();
+            int points = 10; // Participation
+            if (i == 0) points = 100;
+            else if (i == 1) points = 50;
+            else if (i == 2) points = 25;
+
+            allTimePoints.merge(uuid, points, Integer::sum);
+        }
+        save();
+    }
+
+    private void load() {
+        if (!eventsFile.exists()) return;
+        try (FileReader reader = new FileReader(eventsFile)) {
+            JsonObject data = JsonParser.parseReader(reader).getAsJsonObject();
+            if (data.has("activeEvent")) {
+                activeEvent = GSON.fromJson(data.get("activeEvent"), ServerEvent.class);
+            }
+            if (data.has("allTimePoints")) {
+                java.lang.reflect.Type type = new com.google.gson.reflect.TypeToken<Map<String, Integer>>(){}.getType();
+                allTimePoints = GSON.fromJson(data.get("allTimePoints"), type);
+            }
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Failed to load events data", e);
+        }
+    }
+
+    public void save() {
+        try (FileWriter writer = new FileWriter(eventsFile)) {
+            JsonObject data = new JsonObject();
+            if (activeEvent != null) {
+                data.add("activeEvent", GSON.toJsonTree(activeEvent));
+            }
+            data.add("allTimePoints", GSON.toJsonTree(allTimePoints));
+            GSON.toJson(data, writer);
+        } catch (IOException e) {
+            FabricDashboardMod.LOGGER.error("Failed to save events data", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/playtime/dashboard/events/ServerEvent.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/ServerEvent.java
@@ -1,0 +1,34 @@
+package com.playtime.dashboard.events;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Represents a single server-wide event tracking specific player statistics.
+ */
+public class ServerEvent {
+    public String id;
+    public String title;
+    public String type; // e.g., "playtime", "blocks_placed", "blocks_mined", "mob_kills"
+    public long startTime;
+    public long endTime;
+    public boolean isActive;
+
+    // Map of UUID string to the value of the stat when the event started
+    public Map<String, Integer> initialStats = new HashMap<>();
+    
+    // Map of UUID string to the current delta (score)
+    public Map<String, Integer> currentScores = new HashMap<>();
+
+    public ServerEvent() {}
+
+    public ServerEvent(String id, String title, String type, long startTime, long endTime) {
+        this.id = id;
+        this.title = title;
+        this.type = type;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.isActive = true;
+    }
+}

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -112,6 +112,7 @@ public class DashboardWebServer {
             httpServer.createContext("/api/leaderboards", new LeaderboardHandler(leaderboardCacheFile));
             httpServer.createContext("/api/player-stats/", new PlayerStatsHandler(statsAggregator, uuidCache));
             httpServer.createContext("/api/live", new LiveMetricsHandler(this));
+            httpServer.createContext("/api/events", new EventsHandler());
             
             httpServer.setExecutor(Executors.newFixedThreadPool(2));
             httpServer.start();

--- a/backend/src/main/java/com/playtime/dashboard/web/EventsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/EventsHandler.java
@@ -1,0 +1,52 @@
+package com.playtime.dashboard.web;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.playtime.dashboard.events.EventManager;
+import com.playtime.dashboard.events.ServerEvent;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class EventsHandler implements HttpHandler {
+    private static final Gson GSON = new Gson();
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        EventManager manager = EventManager.getInstance();
+        ServerEvent active = manager.getActiveEvent();
+        Map<String, Integer> allTime = manager.getAllTimePoints();
+
+        JsonObject response = new JsonObject();
+        Set<String> allUuids = new HashSet<>(allTime.keySet());
+        if (active != null) {
+            response.add("activeEvent", GSON.toJsonTree(active));
+            allUuids.addAll(active.currentScores.keySet());
+        }
+        response.add("allTimePoints", GSON.toJsonTree(allTime));
+        response.add("uuidToName", GSON.toJsonTree(manager.resolveNames(allUuids)));
+
+        byte[] json = GSON.toJson(response).getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+        exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+        exchange.getResponseHeaders().set("Pragma", "no-cache");
+        exchange.getResponseHeaders().set("Expires", "0");
+        exchange.sendResponseHeaders(200, json.length);
+
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(json);
+        }
+    }
+}

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -447,6 +447,7 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabEvents" class="tab-btn">Events</button>
         <button id="tabLive" class="tab-btn" style="display:{{LIVE_TAB_DISPLAY}};">Live</button>
         <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
@@ -544,6 +545,59 @@
         </div>
       </div>
       </div> <!-- end viewPlaytime -->
+
+      <div id="viewEvents" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">Compete with other players in time-limited server events!</p>
+        
+        <div id="activeEventCard" class="card" style="display:none; border-color: var(--color-primary); background: oklch(from var(--color-primary) 0.12 0.03 h);">
+          <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom: var(--space-4);">
+            <div>
+              <div style="font-size: var(--text-xs); color: var(--color-primary); font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px;">Active Event</div>
+              <h2 id="eventTitle" style="font-size: var(--text-lg); font-weight: 700; margin-bottom: 4px;">Loading...</h2>
+              <div id="eventGoal" style="font-size: var(--text-sm); color: var(--color-text-muted);"></div>
+            </div>
+            <div style="text-align: right;">
+              <div style="font-size: var(--text-xs); color: var(--color-text-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px;">Time Remaining</div>
+              <div id="eventTimer" style="font-size: var(--text-lg); font-weight: 700; color: var(--color-primary);">--:--:--</div>
+            </div>
+          </div>
+          
+          <div class="table-container">
+            <table class="player-table">
+              <thead>
+                <tr>
+                  <th style="width: 80px;">Rank</th>
+                  <th>Player</th>
+                  <th style="text-align: right;" id="eventStatHeader">Score</th>
+                </tr>
+              </thead>
+              <tbody id="eventLeaderboardBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="noActiveEvent" class="card" style="text-align:center; padding: var(--space-12) 0; color: var(--color-text-faint);">
+          <svg style="margin-bottom: var(--space-4); color: var(--color-divider);" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+          <div style="font-size: var(--text-base); font-weight: 600;">No active event.</div>
+          <div style="font-size: var(--text-sm);">Check back later or ask an admin to start one!</div>
+        </div>
+
+        <div class="card">
+          <div class="card-title">All-Time Event Points <span class="card-subtitle">earned from previous events</span></div>
+          <div class="table-container">
+            <table class="player-table">
+              <thead>
+                <tr>
+                  <th style="width: 80px;">Rank</th>
+                  <th>Player</th>
+                  <th style="text-align: right;">Points</th>
+                </tr>
+              </thead>
+              <tbody id="allTimePointsBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </div> <!-- end viewEvents -->
 
       <div id="viewLeaderboards" style="display:none; flex-direction:column; gap:var(--space-6);">
         <p class="page-sub" id="pageSubLeaderboards" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
@@ -1554,8 +1608,8 @@
       }
 
       const updateTabs = (activeId) => {
-        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabLive', 'tabDynmap'];
-        const views = ['viewPlaytime', 'viewLeaderboards', 'viewLive', 'viewDynmap'];
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabEvents', 'tabLive', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewEvents', 'viewLive', 'viewDynmap'];
         tabs.forEach((id, i) => {
           const btn = document.getElementById(id);
           const view = document.getElementById(views[i]);
@@ -1563,7 +1617,6 @@
           if (id === activeId) {
             btn.classList.add('active');
             view.style.display = (id === 'tabDynmap' || id === 'tabLive' || id === 'viewDynmap' || id === 'viewLive') ? 'flex' : 'flex'; 
-            // Correct display logic: use flex for all views except maybe dynmap if it prefers block
             if (id === 'tabDynmap' || id === 'viewDynmap') view.style.display = 'block';
             else view.style.display = 'flex';
           } else {
@@ -1577,7 +1630,149 @@
         } else {
           stopLivePolling();
         }
+
+        if (activeId === 'tabEvents') {
+          startEventsPolling();
+        } else {
+          stopEventsPolling();
+        }
       };
+
+      let eventsPollTimer = null;
+      async function fetchEvents() {
+        try {
+          const res = await fetch('/api/events');
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          const data = await res.json();
+          renderEvents(data);
+        } catch (e) {
+          console.error("[Events] Fetch failed:", e);
+        }
+      }
+
+      function startEventsPolling() {
+        if (eventsPollTimer) return;
+        fetchEvents();
+        eventsPollTimer = setInterval(fetchEvents, 5000);
+      }
+
+      function stopEventsPolling() {
+        if (!eventsPollTimer) return;
+        clearInterval(eventsPollTimer);
+        eventsPollTimer = null;
+      }
+
+      let eventsData = null;
+
+      function renderEvents(data) {
+        eventsData = data;
+        const active = data.activeEvent;
+        const allTime = data.allTimePoints || {};
+
+        const activeCard = document.getElementById('activeEventCard');
+        const noActive = document.getElementById('noActiveEvent');
+
+        if (active && active.isActive) {
+          activeCard.style.display = 'block';
+          noActive.style.display = 'none';
+          document.getElementById('eventTitle').textContent = active.title;
+          
+          const typeLabels = {
+            'playtime': 'Playtime (Minutes)',
+            'blocks_placed': 'Blocks Placed',
+            'blocks_mined': 'Blocks Mined',
+            'mob_kills': 'Mob Kills'
+          };
+          document.getElementById('eventGoal').textContent = `Goal: ${typeLabels[active.type] || active.type}`;
+          document.getElementById('eventStatHeader').textContent = typeLabels[active.type] || 'Score';
+
+          // Timer
+          const updateTimer = () => {
+            const now = Date.now();
+            const diff = active.endTime - now;
+            if (diff <= 0) {
+              document.getElementById('eventTimer').textContent = "00:00:00";
+              return;
+            }
+            const h = Math.floor(diff / 3600000);
+            const m = Math.floor((diff % 3600000) / 60000);
+            const s = Math.floor((diff % 60000) / 1000);
+            document.getElementById('eventTimer').textContent = 
+              `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+          };
+          updateTimer();
+
+          // Leaderboard
+          const lbBody = document.getElementById('eventLeaderboardBody');
+          const scores = Object.entries(active.currentScores || {})
+            .sort((a,b) => b[1] - a[1]);
+          
+          if (scores.length === 0) {
+            lbBody.innerHTML = '<tr><td colspan="3" style="text-align:center; padding: 2rem; color: var(--color-text-faint);">No scores yet. Get started!</td></tr>';
+          } else {
+            lbBody.innerHTML = scores.map(([uuid, val], i) => {
+              let scoreDisplay = val.toLocaleString();
+              if (active.type === 'playtime') {
+                const d = Math.floor(val / 86400);
+                const h = Math.floor((val % 86400) / 3600);
+                const m = Math.floor((val % 3600) / 60);
+                const s = val % 60;
+                scoreDisplay = (d > 0 ? d + 'd ' : '') + 
+                               (h > 0 || d > 0 ? h + 'h ' : '') + 
+                               (m > 0 || h > 0 || d > 0 ? m + 'm ' : '') + 
+                               s + 's';
+              }
+              return `
+                <tr onclick="showPlayerDetails('${getPlayerNameByUuid(uuid)}')">
+                  <td><span class="rank-badge ${i < 3 ? rankClass[i] : ''}">${i + 1}</span></td>
+                  <td><div style="display:flex; align-items:center; gap:var(--space-3);">${playerHeadByUuid(uuid, 24)}<span style="font-weight:600;">${getPlayerNameByUuid(uuid)}</span></div></td>
+                  <td style="text-align: right; font-weight: 700;">${scoreDisplay}</td>
+                </tr>
+              `;
+            }).join('');
+          }
+        } else {
+          activeCard.style.display = 'none';
+          noActive.style.display = 'block';
+        }
+
+        // All-Time
+        const allTimeBody = document.getElementById('allTimePointsBody');
+        const sortedAllTime = Object.entries(allTime).sort((a,b) => b[1] - a[1]);
+        if (sortedAllTime.length === 0) {
+          allTimeBody.innerHTML = '<tr><td colspan="3" style="text-align:center;">No points awarded yet.</td></tr>';
+        } else {
+          allTimeBody.innerHTML = sortedAllTime.map(([uuid, pts], i) => `
+            <tr onclick="showPlayerDetails('${getPlayerNameByUuid(uuid)}')">
+              <td><span class="rank-badge ${i < 3 ? rankClass[i] : ''}">${i + 1}</span></td>
+              <td><div style="display:flex; align-items:center; gap:var(--space-3);">${playerHeadByUuid(uuid, 24)}<span style="font-weight:600;">${getPlayerNameByUuid(uuid)}</span></div></td>
+              <td style="text-align: right; font-weight: 700; color: var(--color-primary);">${pts.toLocaleString()} pts</td>
+            </tr>
+          `).join('');
+        }
+      }
+
+      function getPlayerNameByUuid(uuid) {
+        if (!uuid) return "Unknown";
+        // 1. Check uuidToName map from events API
+        if (eventsData && eventsData.uuidToName && eventsData.uuidToName[uuid]) {
+          return eventsData.uuidToName[uuid];
+        }
+        // 2. Check PLAYER_META (name -> {uuid, colorHex})
+        for (const [name, meta] of Object.entries(PLAYER_META)) {
+          if (meta.uuid === uuid) return name;
+        }
+        // 3. Check sessData keys (names)
+        for (const name of Object.keys(sessData)) {
+          if (name === uuid) return name;
+        }
+        return uuid;
+      }
+
+      function playerHeadByUuid(uuid, size) {
+        const name = getPlayerNameByUuid(uuid);
+        return `<img src="/faces/${encodeURIComponent(name)}.png" class="player-head" width="${size}" height="${size}" onerror="this.src='/faces/default_head.png'">`;
+      }
 
       async function fetchLiveMetrics() {
         try {
@@ -1700,11 +1895,14 @@
         lastUpd.style.color = "var(--color-text-muted)";
       }
 
-      document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
-      document.getElementById('tabLeaderboards').addEventListener('click', () => { 
+      document.getElementById('tabPlaytime').onclick = () => updateTabs('tabPlaytime');
+      document.getElementById('tabLeaderboards').onclick = () => { 
         updateTabs('tabLeaderboards'); 
         if (!leaderboardsData) loadLeaderboards(); 
-      });
+      };
+      document.getElementById('tabEvents').onclick = () => updateTabs('tabEvents');
+      document.getElementById('tabLive').onclick = () => updateTabs('tabLive');
+      document.getElementById('tabDynmap').onclick = () => updateTabs('tabDynmap');
       document.getElementById('tabLive').addEventListener('click', () => updateTabs('tabLive'));
       document.getElementById('tabDynmap').addEventListener('click', () => {
         console.log("[Playtime] Switching to Dynmap tab...");

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,17 @@ The mod features an embedded lightweight HTTP server that runs quietly in the ba
 *   **State-Preserving Tabs**: Switch between playtime stats and the live map without losing your zoom level or position.
 *   **Togglable**: Easily enable or disable the map tab via configuration.
 
+### ⚡ Live Server Performance
+*   **Real-Time Metrics**: Monitor Server TPS, MSPT (Tick Times), CPU usage, and JVM Memory directly from the dashboard.
+*   **Container Optimized**: Specialized support for Pterodactyl/Docker environments, reporting actual folder size (`/home/container`) rather than misleading host partition data.
+*   **Live Player List**: See who is online right now. Click any online player to jump straight to their full activity history.
+*   **Color-Coded Status**: Visual health indicators (Green/Yellow/Red) for at-a-glance monitoring.
+
+### 🎖️ Server Events & Competitions
+*   **Admin-Driven Events**: Create timed competitions (e.g., "Most Hours This Week" or "Most Mob Kills") using `/dashboard event create`.
+*   **Live Scoreboards**: Progress is tracked in real-time on a premium in-game sidebar, featuring formatted time displays (`Dd Hh Mm Ss`) for playtime and hidden raw scores for a clean look.
+*   **Web Leaderboard**: A dedicated "Events" tab on the dashboard provides a live, interactive view of the competition for players outside the game.
+*   **Automatic Rewards**: At the end of each event, players earn "All-Time Points" based on their placement, which are tracked on a permanent server-wide leaderboard.
 ## Getting Started
 
 ### Prerequisites
@@ -50,6 +61,17 @@ The `syncWebAssets` task automatically copies the frontend files from `frontend/
 Once built, drop the resulting `.jar` file from `backend/build/libs/` into your server's `mods` folder and start the server.
 
 By default, the dashboard is accessible at `http://<your-server-ip>:8105`.
+
+## Server Commands
+All commands require Operator level 2 permission.
+
+| Command | Description |
+| :--- | :--- |
+| `/dashboard event create <type> <hours> <title>` | Start a new timed event (playtime, mob_kills, blocks_placed, blocks_mined). |
+| `/dashboard event stop` | Manually end the current event and distribute points. |
+| `/dashboard event status` | View details and remaining time for the active event. |
+| `/dashboard event clearpoints all [amount]` | Clear or reduce all-time points for all players. |
+| `/dashboard event clearpoints user <name> [amount]` | Clear or reduce all-time points for a specific player. |
 
 ## Configuration
 Settings are managed via `config/dashboard-config.json`. The file is automatically generated on first run.

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -447,6 +447,7 @@
       <div style="display:flex; gap:var(--space-4); border-bottom:1px solid var(--color-divider); margin-bottom:var(--space-2);">
         <button id="tabPlaytime" class="tab-btn active">Playtime</button>
         <button id="tabLeaderboards" class="tab-btn">Leaderboards</button>
+        <button id="tabEvents" class="tab-btn">Events</button>
         <button id="tabLive" class="tab-btn" style="display:{{LIVE_TAB_DISPLAY}};">Live</button>
         <button id="tabDynmap" class="tab-btn" style="display:none;">Dynmap</button>
       </div>
@@ -544,6 +545,59 @@
         </div>
       </div>
       </div> <!-- end viewPlaytime -->
+
+      <div id="viewEvents" style="display:none; flex-direction:column; gap:var(--space-6);">
+        <p class="page-sub" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">Compete with other players in time-limited server events!</p>
+        
+        <div id="activeEventCard" class="card" style="display:none; border-color: var(--color-primary); background: oklch(from var(--color-primary) 0.12 0.03 h);">
+          <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom: var(--space-4);">
+            <div>
+              <div style="font-size: var(--text-xs); color: var(--color-primary); font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px;">Active Event</div>
+              <h2 id="eventTitle" style="font-size: var(--text-lg); font-weight: 700; margin-bottom: 4px;">Loading...</h2>
+              <div id="eventGoal" style="font-size: var(--text-sm); color: var(--color-text-muted);"></div>
+            </div>
+            <div style="text-align: right;">
+              <div style="font-size: var(--text-xs); color: var(--color-text-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px;">Time Remaining</div>
+              <div id="eventTimer" style="font-size: var(--text-lg); font-weight: 700; color: var(--color-primary);">--:--:--</div>
+            </div>
+          </div>
+          
+          <div class="table-container">
+            <table class="player-table">
+              <thead>
+                <tr>
+                  <th style="width: 80px;">Rank</th>
+                  <th>Player</th>
+                  <th style="text-align: right;" id="eventStatHeader">Score</th>
+                </tr>
+              </thead>
+              <tbody id="eventLeaderboardBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="noActiveEvent" class="card" style="text-align:center; padding: var(--space-12) 0; color: var(--color-text-faint);">
+          <svg style="margin-bottom: var(--space-4); color: var(--color-divider);" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+          <div style="font-size: var(--text-base); font-weight: 600;">No active event.</div>
+          <div style="font-size: var(--text-sm);">Check back later or ask an admin to start one!</div>
+        </div>
+
+        <div class="card">
+          <div class="card-title">All-Time Event Points <span class="card-subtitle">earned from previous events</span></div>
+          <div class="table-container">
+            <table class="player-table">
+              <thead>
+                <tr>
+                  <th style="width: 80px;">Rank</th>
+                  <th>Player</th>
+                  <th style="text-align: right;">Points</th>
+                </tr>
+              </thead>
+              <tbody id="allTimePointsBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </div> <!-- end viewEvents -->
 
       <div id="viewLeaderboards" style="display:none; flex-direction:column; gap:var(--space-6);">
         <p class="page-sub" id="pageSubLeaderboards" style="margin-top: 0; margin-bottom: calc(var(--space-2) * -1);">{{DASHBOARD_DESCRIPTION}}</p>
@@ -1554,8 +1608,8 @@
       }
 
       const updateTabs = (activeId) => {
-        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabLive', 'tabDynmap'];
-        const views = ['viewPlaytime', 'viewLeaderboards', 'viewLive', 'viewDynmap'];
+        const tabs = ['tabPlaytime', 'tabLeaderboards', 'tabEvents', 'tabLive', 'tabDynmap'];
+        const views = ['viewPlaytime', 'viewLeaderboards', 'viewEvents', 'viewLive', 'viewDynmap'];
         tabs.forEach((id, i) => {
           const btn = document.getElementById(id);
           const view = document.getElementById(views[i]);
@@ -1563,7 +1617,6 @@
           if (id === activeId) {
             btn.classList.add('active');
             view.style.display = (id === 'tabDynmap' || id === 'tabLive' || id === 'viewDynmap' || id === 'viewLive') ? 'flex' : 'flex'; 
-            // Correct display logic: use flex for all views except maybe dynmap if it prefers block
             if (id === 'tabDynmap' || id === 'viewDynmap') view.style.display = 'block';
             else view.style.display = 'flex';
           } else {
@@ -1577,7 +1630,149 @@
         } else {
           stopLivePolling();
         }
+
+        if (activeId === 'tabEvents') {
+          startEventsPolling();
+        } else {
+          stopEventsPolling();
+        }
       };
+
+      let eventsPollTimer = null;
+      async function fetchEvents() {
+        try {
+          const res = await fetch('/api/events');
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          const data = await res.json();
+          renderEvents(data);
+        } catch (e) {
+          console.error("[Events] Fetch failed:", e);
+        }
+      }
+
+      function startEventsPolling() {
+        if (eventsPollTimer) return;
+        fetchEvents();
+        eventsPollTimer = setInterval(fetchEvents, 5000);
+      }
+
+      function stopEventsPolling() {
+        if (!eventsPollTimer) return;
+        clearInterval(eventsPollTimer);
+        eventsPollTimer = null;
+      }
+
+      let eventsData = null;
+
+      function renderEvents(data) {
+        eventsData = data;
+        const active = data.activeEvent;
+        const allTime = data.allTimePoints || {};
+
+        const activeCard = document.getElementById('activeEventCard');
+        const noActive = document.getElementById('noActiveEvent');
+
+        if (active && active.isActive) {
+          activeCard.style.display = 'block';
+          noActive.style.display = 'none';
+          document.getElementById('eventTitle').textContent = active.title;
+          
+          const typeLabels = {
+            'playtime': 'Playtime (Minutes)',
+            'blocks_placed': 'Blocks Placed',
+            'blocks_mined': 'Blocks Mined',
+            'mob_kills': 'Mob Kills'
+          };
+          document.getElementById('eventGoal').textContent = `Goal: ${typeLabels[active.type] || active.type}`;
+          document.getElementById('eventStatHeader').textContent = typeLabels[active.type] || 'Score';
+
+          // Timer
+          const updateTimer = () => {
+            const now = Date.now();
+            const diff = active.endTime - now;
+            if (diff <= 0) {
+              document.getElementById('eventTimer').textContent = "00:00:00";
+              return;
+            }
+            const h = Math.floor(diff / 3600000);
+            const m = Math.floor((diff % 3600000) / 60000);
+            const s = Math.floor((diff % 60000) / 1000);
+            document.getElementById('eventTimer').textContent = 
+              `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+          };
+          updateTimer();
+
+          // Leaderboard
+          const lbBody = document.getElementById('eventLeaderboardBody');
+          const scores = Object.entries(active.currentScores || {})
+            .sort((a,b) => b[1] - a[1]);
+          
+          if (scores.length === 0) {
+            lbBody.innerHTML = '<tr><td colspan="3" style="text-align:center; padding: 2rem; color: var(--color-text-faint);">No scores yet. Get started!</td></tr>';
+          } else {
+            lbBody.innerHTML = scores.map(([uuid, val], i) => {
+              let scoreDisplay = val.toLocaleString();
+              if (active.type === 'playtime') {
+                const d = Math.floor(val / 86400);
+                const h = Math.floor((val % 86400) / 3600);
+                const m = Math.floor((val % 3600) / 60);
+                const s = val % 60;
+                scoreDisplay = (d > 0 ? d + 'd ' : '') + 
+                               (h > 0 || d > 0 ? h + 'h ' : '') + 
+                               (m > 0 || h > 0 || d > 0 ? m + 'm ' : '') + 
+                               s + 's';
+              }
+              return `
+                <tr onclick="showPlayerDetails('${getPlayerNameByUuid(uuid)}')">
+                  <td><span class="rank-badge ${i < 3 ? rankClass[i] : ''}">${i + 1}</span></td>
+                  <td><div style="display:flex; align-items:center; gap:var(--space-3);">${playerHeadByUuid(uuid, 24)}<span style="font-weight:600;">${getPlayerNameByUuid(uuid)}</span></div></td>
+                  <td style="text-align: right; font-weight: 700;">${scoreDisplay}</td>
+                </tr>
+              `;
+            }).join('');
+          }
+        } else {
+          activeCard.style.display = 'none';
+          noActive.style.display = 'block';
+        }
+
+        // All-Time
+        const allTimeBody = document.getElementById('allTimePointsBody');
+        const sortedAllTime = Object.entries(allTime).sort((a,b) => b[1] - a[1]);
+        if (sortedAllTime.length === 0) {
+          allTimeBody.innerHTML = '<tr><td colspan="3" style="text-align:center;">No points awarded yet.</td></tr>';
+        } else {
+          allTimeBody.innerHTML = sortedAllTime.map(([uuid, pts], i) => `
+            <tr onclick="showPlayerDetails('${getPlayerNameByUuid(uuid)}')">
+              <td><span class="rank-badge ${i < 3 ? rankClass[i] : ''}">${i + 1}</span></td>
+              <td><div style="display:flex; align-items:center; gap:var(--space-3);">${playerHeadByUuid(uuid, 24)}<span style="font-weight:600;">${getPlayerNameByUuid(uuid)}</span></div></td>
+              <td style="text-align: right; font-weight: 700; color: var(--color-primary);">${pts.toLocaleString()} pts</td>
+            </tr>
+          `).join('');
+        }
+      }
+
+      function getPlayerNameByUuid(uuid) {
+        if (!uuid) return "Unknown";
+        // 1. Check uuidToName map from events API
+        if (eventsData && eventsData.uuidToName && eventsData.uuidToName[uuid]) {
+          return eventsData.uuidToName[uuid];
+        }
+        // 2. Check PLAYER_META (name -> {uuid, colorHex})
+        for (const [name, meta] of Object.entries(PLAYER_META)) {
+          if (meta.uuid === uuid) return name;
+        }
+        // 3. Check sessData keys (names)
+        for (const name of Object.keys(sessData)) {
+          if (name === uuid) return name;
+        }
+        return uuid;
+      }
+
+      function playerHeadByUuid(uuid, size) {
+        const name = getPlayerNameByUuid(uuid);
+        return `<img src="/faces/${encodeURIComponent(name)}.png" class="player-head" width="${size}" height="${size}" onerror="this.src='/faces/default_head.png'">`;
+      }
 
       async function fetchLiveMetrics() {
         try {
@@ -1700,11 +1895,14 @@
         lastUpd.style.color = "var(--color-text-muted)";
       }
 
-      document.getElementById('tabPlaytime').addEventListener('click', () => updateTabs('tabPlaytime'));
-      document.getElementById('tabLeaderboards').addEventListener('click', () => { 
+      document.getElementById('tabPlaytime').onclick = () => updateTabs('tabPlaytime');
+      document.getElementById('tabLeaderboards').onclick = () => { 
         updateTabs('tabLeaderboards'); 
         if (!leaderboardsData) loadLeaderboards(); 
-      });
+      };
+      document.getElementById('tabEvents').onclick = () => updateTabs('tabEvents');
+      document.getElementById('tabLive').onclick = () => updateTabs('tabLive');
+      document.getElementById('tabDynmap').onclick = () => updateTabs('tabDynmap');
       document.getElementById('tabLive').addEventListener('click', () => updateTabs('tabLive'));
       document.getElementById('tabDynmap').addEventListener('click', () => {
         console.log("[Playtime] Switching to Dynmap tab...");


### PR DESCRIPTION
This PR implements a comprehensive **Server Event & Competition** system.

### Key Features:
*   **Timed Competitions**: Admins can start events for Playtime, Mob Kills, Blocks Placed, and Blocks Mined via `/dashboard event create`.
*   **Premium In-Game Scoreboard**: Real-time tracking on the sidebar with custom formatting (e.g., `0d 2h 15m 30s`) and hidden raw scores for a clean look.
*   **Live Web Leaderboard**: A new "Events" tab on the dashboard provides a live view of the competition.
*   **All-Time Points**: Players earn points based on their placement at the end of each event, tracked on a server-wide leaderboard.
*   **Point Management**: New admin commands to clear or reduce all-time points.
*   **1.21.1 Native Support**: Utilizes the latest Minecraft Scoreboard APIs (Display Text, Number Formatting).

### Commits:
*   `feat: implement live server events with premium in-game scoreboard and all-time leaderboard`

Closes # [if there was an issue]
