### PR TITLE
chore: remove duplicate root README symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-docs/README.md


### PR DESCRIPTION
This is a minor cleanup to follow the project's documentation convention.
* Removed the duplicate `README.md` symlink from the root directory.
* The primary documentation remains in `docs/README.md` as per `GEMINI.md`.