### PR TITLE
feat: add player heads to scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-docs/README.md

--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -35,6 +35,7 @@ public class DashboardConfig {
     public String dynmap_url = "http://149.56.155.7:8032";
     public boolean enable_live_tab = true;
     public int live_update_interval_seconds = 3;
+    public String resource_pack_url = "http://149.56.155.7:8105/respack.zip"; // Sets resource-pack in server.properties if not empty
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static DashboardConfig instance;

--- a/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
@@ -86,6 +86,17 @@ public class EventManager {
         // Take snapshot of initial stats for all known players
         takeStatsSnapshot();
         save();
+        
+        List<String> onlineNames = server.getPlayerManager().getPlayerList().stream()
+            .map(p -> p.getGameProfile().getName())
+            .collect(Collectors.toList());
+        com.playtime.dashboard.util.PlayerHeadFontManager.registerKnownPlayers(onlineNames);
+        
+        new Thread(() -> {
+            com.playtime.dashboard.util.PlayerHeadFontManager.buildRespack();
+            com.playtime.dashboard.util.PlayerHeadFontManager.zipRespack();
+        }, "Dashboard-Respack-Builder").start();
+
         updateScoreboard();
         
         server.getPlayerManager().broadcast(Text.literal("§6[Event] §aNew event started: §l" + title), false);
@@ -307,18 +318,29 @@ public class EventManager {
                 ScoreHolder holder = ScoreHolder.fromName(name);
                 var score = scoreboard.getOrCreateScore(holder, finalObjective);
                 
+                String glyph = com.playtime.dashboard.util.PlayerHeadFontManager.getHeadGlyph(name);
+                net.minecraft.text.MutableText text = Text.empty();
+                if (!glyph.isEmpty()) {
+                    text.append(Text.literal(glyph).setStyle(net.minecraft.text.Style.EMPTY.withFont(Identifier.of("dashboard", "heads"))));
+                }
+                text.append(Text.literal(" §f" + name));
+
                 if (activeEvent.type.equals("playtime")) {
                     String formattedTime = formatTime(val);
-                    score.setDisplayText(Text.literal("§f" + name + " §e" + formattedTime));
+                    text.append(Text.literal(" §e" + formattedTime));
+                    score.setDisplayText(text);
                     // Try to hide the score number if the class exists, otherwise it just shows alongside
                     try {
                         score.setNumberFormat(BlankNumberFormat.INSTANCE);
                     } catch (Throwable ignored) {}
                 } else {
-                    score.setDisplayText(null); // Reset to default
+                    score.setDisplayText(text);
                     score.setNumberFormat(null);
                 }
                 
+                // Debug logging
+                FabricDashboardMod.LOGGER.debug("Scoreboard update for {}: glyph='{}', val={}", name, glyph, val);
+
                 score.setScore(val);
             });
     }

--- a/backend/src/main/java/com/playtime/dashboard/util/PlayerHeadFontManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/util/PlayerHeadFontManager.java
@@ -1,0 +1,305 @@
+package com.playtime.dashboard.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.playtime.dashboard.FabricDashboardMod;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class PlayerHeadFontManager {
+    private static final int BASE_CODEPOINT = 0xE000;
+    private static final Map<String, Integer> playerSlots = new ConcurrentHashMap<>();
+    private static int nextSlot = 0;
+    
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static void loadSlots() {
+        File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+        File facesDir = new File(gameDir, "dashboard_faces");
+        File slotsFile = new File(facesDir, "slots.json");
+        if (slotsFile.exists()) {
+            try (FileReader reader = new FileReader(slotsFile)) {
+                JsonObject json = com.google.gson.JsonParser.parseReader(reader).getAsJsonObject();
+                for (String key : json.keySet()) {
+                    int slot = json.get(key).getAsInt();
+                    playerSlots.put(key, slot);
+                    if (slot >= nextSlot) {
+                        nextSlot = slot + 1;
+                    }
+                }
+            } catch (Exception e) {
+                FabricDashboardMod.LOGGER.error("Failed to load slots.json", e);
+            }
+        }
+    }
+
+    private static void saveSlots() {
+        File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+        File facesDir = new File(gameDir, "dashboard_faces");
+        facesDir.mkdirs();
+        File slotsFile = new File(facesDir, "slots.json");
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(slotsFile), java.nio.charset.StandardCharsets.UTF_8)) {
+            JsonObject json = new JsonObject();
+            for (Map.Entry<String, Integer> entry : playerSlots.entrySet()) {
+                json.addProperty(entry.getKey(), entry.getValue());
+            }
+            GSON.toJson(json, writer);
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Failed to save slots.json", e);
+        }
+    }
+
+    public static String getHeadGlyph(String playerName) {
+        if (playerSlots.isEmpty() && nextSlot == 0) {
+            loadSlots();
+        }
+
+        File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+        File facesDir = new File(gameDir, "dashboard_faces");
+        String sanitized = sanitizeFilename(playerName);
+        File faceFile = new File(facesDir, sanitized + ".png");
+
+        if (!faceFile.exists()) {
+            FabricDashboardMod.LOGGER.debug("No face PNG found for {} at {}, returning empty glyph.", playerName, faceFile.getAbsolutePath());
+            return "";
+        }
+
+        boolean[] isNew = {false};
+        int slot = playerSlots.computeIfAbsent(playerName, k -> {
+            synchronized (PlayerHeadFontManager.class) {
+                isNew[0] = true;
+                return nextSlot++;
+            }
+        });
+        
+        if (isNew[0]) {
+            FabricDashboardMod.LOGGER.info("Assigned new font slot {} (charCode={}) to {}", slot, Integer.toHexString(BASE_CODEPOINT + slot), playerName);
+            saveSlots();
+        }
+
+        return String.valueOf((char) (BASE_CODEPOINT + slot));
+    }
+
+    public static void registerKnownPlayers(Iterable<String> onlinePlayers) {
+        File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+        File facesDir = new File(gameDir, "dashboard_faces");
+        File metaFile = new File(facesDir, "meta.json");
+
+        if (onlinePlayers != null) {
+            for (String name : onlinePlayers) {
+                getHeadGlyph(name);
+            }
+        }
+
+        if (metaFile.exists()) {
+            try (FileReader reader = new FileReader(metaFile)) {
+                JsonObject meta = com.google.gson.JsonParser.parseReader(reader).getAsJsonObject();
+                for (String playerName : meta.keySet()) {
+                    getHeadGlyph(playerName);
+                }
+            } catch (Exception e) {
+                FabricDashboardMod.LOGGER.error("Failed to parse meta.json in registerKnownPlayers", e);
+            }
+        }
+    }
+
+    public static void buildRespack() {
+        try {
+            File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+            File respackDir = new File(gameDir, "dashboard_respack");
+            
+            // Clean existing directory
+            if (respackDir.exists()) {
+                deleteDirectory(respackDir.toPath());
+            }
+
+            File texturesDir = new File(respackDir, "assets/dashboard/textures/font/heads");
+            File fontDir = new File(respackDir, "assets/dashboard/font");
+            
+            texturesDir.mkdirs();
+            fontDir.mkdirs();
+
+            File facesDir = new File(gameDir, "dashboard_faces");
+            JsonArray providers = new JsonArray();
+
+            for (Map.Entry<String, Integer> entry : playerSlots.entrySet()) {
+                String playerName = entry.getKey();
+                int slot = entry.getValue();
+                String sanitized = sanitizeFilename(playerName);
+                String respackAssetName = sanitized.toLowerCase();
+                
+                File sourceFile = new File(facesDir, sanitized + ".png");
+                if (sourceFile.exists()) {
+                    File destFile = new File(texturesDir, respackAssetName + ".png");
+                    Files.copy(sourceFile.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    
+                    JsonObject provider = new JsonObject();
+                    provider.addProperty("type", "bitmap");
+                    provider.addProperty("file", "dashboard:font/heads/" + respackAssetName + ".png");
+                    provider.addProperty("ascent", 8);
+                    provider.addProperty("height", 9);
+                    JsonArray chars = new JsonArray();
+                    chars.add(String.valueOf((char) (BASE_CODEPOINT + slot)));
+                    provider.add("chars", chars);
+                    providers.add(provider);
+                    FabricDashboardMod.LOGGER.debug("Added font provider for {}: file={}, charCode={}", playerName, respackAssetName + ".png", Integer.toHexString(BASE_CODEPOINT + slot));
+                } else {
+                    FabricDashboardMod.LOGGER.warn("Face PNG not found for {} at {}", playerName, sourceFile.getAbsolutePath());
+                }
+            }
+
+            JsonObject fontJson = new JsonObject();
+            fontJson.add("providers", providers);
+
+            File headsJsonFile = new File(fontDir, "heads.json");
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(headsJsonFile), java.nio.charset.StandardCharsets.UTF_8)) {
+                GSON.toJson(fontJson, writer);
+            }
+
+            File packMcmetaFile = new File(respackDir, "pack.mcmeta");
+            JsonObject packMcmeta = new JsonObject();
+            JsonObject packInfo = new JsonObject();
+            packInfo.addProperty("pack_format", 34);
+            packInfo.addProperty("description", "Dashboard Player Heads");
+            packMcmeta.add("pack", packInfo);
+            
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(packMcmetaFile), java.nio.charset.StandardCharsets.UTF_8)) {
+                GSON.toJson(packMcmeta, writer);
+            }
+            
+            FabricDashboardMod.LOGGER.info("Successfully built dashboard_respack directory.");
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Failed to build resource pack", e);
+        }
+    }
+
+    public static void zipRespack() {
+        try {
+            File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+            File respackDir = new File(gameDir, "dashboard_respack");
+            File zipFile = new File(gameDir, "dashboard_respack.zip");
+            
+            if (!respackDir.exists()) {
+                return;
+            }
+
+            try (FileOutputStream fos = new FileOutputStream(zipFile);
+                 ZipOutputStream zos = new ZipOutputStream(fos)) {
+                
+                Path sourcePath = respackDir.toPath();
+                java.util.List<Path> paths = new java.util.ArrayList<>();
+                Files.walkFileTree(sourcePath, new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        paths.add(file);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+                
+                // Sort paths to ensure deterministic order
+                paths.sort(java.util.Comparator.comparing(Path::toString));
+                
+                for (Path file : paths) {
+                    String zipEntryName = sourcePath.relativize(file).toString().replace('\\', '/');
+                    ZipEntry entry = new ZipEntry(zipEntryName);
+                    // Force a constant timestamp so the ZIP hash doesn't change arbitrarily
+                    entry.setTime(0);
+                    zos.putNextEntry(entry);
+                    Files.copy(file, zos);
+                    zos.closeEntry();
+                }
+            }
+            
+            String sha1 = calculateSHA1(zipFile);
+            FabricDashboardMod.LOGGER.info("Successfully created dashboard_respack.zip! SHA-1: " + sha1);
+            updateServerPropertiesHash(gameDir, sha1);
+        } catch (Exception e) {
+            FabricDashboardMod.LOGGER.error("Failed to zip resource pack", e);
+        }
+    }
+
+    private static void updateServerPropertiesHash(File gameDir, String newHash) {
+        File serverProps = new File(gameDir, "server.properties");
+        if (!serverProps.exists()) {
+            return;
+        }
+
+        try {
+            java.util.List<String> lines = Files.readAllLines(serverProps.toPath(), java.nio.charset.StandardCharsets.UTF_8);
+            boolean foundHash = false;
+            boolean foundUrl = false;
+            String targetUrl = com.playtime.dashboard.config.DashboardConfig.get().resource_pack_url;
+
+            for (int i = 0; i < lines.size(); i++) {
+                if (lines.get(i).startsWith("resource-pack-sha1=")) {
+                    lines.set(i, "resource-pack-sha1=" + newHash);
+                    foundHash = true;
+                } else if (targetUrl != null && !targetUrl.trim().isEmpty() && lines.get(i).startsWith("resource-pack=")) {
+                    lines.set(i, "resource-pack=" + targetUrl);
+                    foundUrl = true;
+                }
+            }
+            if (!foundHash) {
+                lines.add("resource-pack-sha1=" + newHash);
+            }
+            if (!foundUrl && targetUrl != null && !targetUrl.trim().isEmpty()) {
+                lines.add("resource-pack=" + targetUrl);
+            }
+            Files.write(serverProps.toPath(), lines, java.nio.charset.StandardCharsets.UTF_8);
+            FabricDashboardMod.LOGGER.info("Automagically updated server.properties with the new resource-pack-sha1: " + newHash);
+            if (targetUrl != null && !targetUrl.trim().isEmpty()) {
+                FabricDashboardMod.LOGGER.info("Automagically updated server.properties with resource-pack=" + targetUrl);
+            }
+            FabricDashboardMod.LOGGER.info("Note: You may need to restart the server for Minecraft to load the new hash from server.properties.");
+        } catch (IOException e) {
+            FabricDashboardMod.LOGGER.error("Failed to update server.properties", e);
+        }
+    }
+
+    private static String calculateSHA1(File file) throws Exception {
+        java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-1");
+        try (java.io.InputStream is = new java.io.FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                md.update(buffer, 0, read);
+            }
+        }
+        byte[] digest = md.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static void deleteDirectory(Path path) throws IOException {
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static String sanitizeFilename(String playerName) {
+        if (playerName == null) return "unknown";
+        return playerName.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+    }
+}

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -114,6 +114,7 @@ public class DashboardWebServer {
             httpServer.createContext("/api/player-advancements/", new PlayerAdvancementsHandler(statsAggregator, uuidCache));
             httpServer.createContext("/api/live", new LiveMetricsHandler(this));
             httpServer.createContext("/api/events", new EventsHandler());
+            httpServer.createContext("/respack.zip", new RespackHandler());
             
             httpServer.setExecutor(Executors.newFixedThreadPool(2));
             httpServer.start();
@@ -745,6 +746,42 @@ public class DashboardWebServer {
             
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(response);
+            }
+        }
+    }
+
+    private static class RespackHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+
+            File gameDir = FabricLoader.getInstance().getGameDir().toFile();
+            File respackZip = new File(gameDir, "dashboard_respack.zip");
+
+            if (!respackZip.exists() || !respackZip.isFile()) {
+                FabricDashboardMod.LOGGER.warn("Client requested respack.zip but it does not exist.");
+                exchange.sendResponseHeaders(404, -1);
+                return;
+            }
+            
+            FabricDashboardMod.LOGGER.info("Serving respack.zip to client: " + exchange.getRemoteAddress() + " (size: " + respackZip.length() + " bytes)");
+
+            exchange.getResponseHeaders().set("Content-Type", "application/zip");
+            exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+            exchange.getResponseHeaders().set("Pragma", "no-cache");
+            exchange.getResponseHeaders().set("Expires", "0");
+            exchange.sendResponseHeaders(200, respackZip.length());
+
+            try (InputStream is = new FileInputStream(respackZip);
+                 OutputStream os = exchange.getResponseBody()) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = is.read(buffer)) != -1) {
+                    os.write(buffer, 0, bytesRead);
+                }
             }
         }
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ The mod features an embedded lightweight HTTP server that runs quietly in the ba
 ### 🎖️ Server Events & Competitions
 *   **Admin-Driven Events**: Create timed competitions (e.g., "Most Hours This Week" or "Most Mob Kills") using `/dashboard event create`.
 *   **Live Scoreboards**: Progress is tracked in real-time on a premium in-game sidebar, featuring formatted time displays (`Dd Hh Mm Ss`) for playtime and hidden raw scores for a clean look.
+*   **Player Head Rendering**: The mod automatically generates a dynamic resource pack mapping player face PNGs to custom Unicode characters. This allows the in-game event scoreboard to render player head icons natively, right beside their names!
 *   **Web Leaderboard**: A dedicated "Events" tab on the dashboard provides a live, interactive view of the competition for players outside the game.
 *   **Automatic Rewards**: At the end of each event, players earn "All-Time Points" based on their placement, which are tracked on a permanent server-wide leaderboard.
 ## Getting Started
@@ -96,6 +97,7 @@ Settings are managed via `config/dashboard-config.json`. The file is automatical
 | `incremental_update_interval_minutes` | `5` | Frequency of log scanning for new data. |
 | `leaderboard_update_interval_minutes` | `10` | Frequency of world stats aggregation. |
 | `fetch_player_heads` | `true` | Enable fetching skin textures from Mojang API. |
+| `resource_pack_url` | `"http://<ip>:8105/respack.zip"` | The URL where clients download the dynamically generated custom font resource pack. Automatically synced to `server.properties`. |
 | `enable_live_tab` | `true` | Toggle the Live Metrics tab on/off. |
 | `live_update_interval_seconds` | `3` | Frequency of performance metrics polling. |
 


### PR DESCRIPTION
## Summary
* Added `PlayerHeadFontManager` utility to dynamically generate a resource pack mapping player face PNGs to private-use Unicode characters.
* Modified `EventManager` to construct `MutableText` blocks incorporating the generated Unicode characters on the scoreboard.
* Added a new `/respack.zip` endpoint to the `DashboardWebServer` to serve the generated resource pack.
* Automatically hashes the resource pack and injects `resource-pack-sha1` and `resource-pack` configurations into the `server.properties` file on event start to force client updates.

This fully implements the feature requested to show player head icons natively on the scoreboard without external dependencies.