### PR TITLE
feat: Enhanced Server Events Scoreboard & Obsidian Tracking

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
+++ b/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
@@ -11,6 +11,8 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DashboardCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
@@ -23,6 +25,8 @@ public class DashboardCommand {
                             builder.suggest("playtime");
                             builder.suggest("blocks_placed");
                             builder.suggest("blocks_mined");
+                            builder.suggest("obsidian_placed");
+                            builder.suggest("obsidian_mined");
                             builder.suggest("mob_kills");
                             builder.suggest("fewest_deaths");
                             builder.suggest("damage_dealt");
@@ -56,16 +60,7 @@ public class DashboardCommand {
                 )
                 .then(CommandManager.literal("list")
                     .executes(context -> {
-                        List<ServerEvent> active = EventManager.getInstance().getActiveEvents();
-                        if (active.isEmpty()) {
-                            context.getSource().sendFeedback(() -> Text.literal("§eNo active events."), false);
-                        } else {
-                            context.getSource().sendFeedback(() -> Text.literal("§6--- Active Events ---"), false);
-                            for (ServerEvent event : active) {
-                                long remaining = (event.endTime - System.currentTimeMillis()) / 1000;
-                                context.getSource().sendFeedback(() -> Text.literal("§e" + event.title + " §7(" + event.id.substring(0, 8) + ") - " + event.type + " §f[" + (remaining / 3600) + "h " + ((remaining % 3600) / 60) + "m left]"), false);
-                            }
-                        }
+                        sendEventOverview(context.getSource());
                         return 1;
                     })
                 )
@@ -122,18 +117,25 @@ public class DashboardCommand {
                 )
                 .then(CommandManager.literal("status")
                     .executes(context -> {
-                        List<ServerEvent> active = EventManager.getInstance().getActiveEvents();
-                        if (active.isEmpty()) {
-                            context.getSource().sendFeedback(() -> Text.literal("§eNo active events."), false);
-                        } else {
-                            context.getSource().sendFeedback(() -> Text.literal("§6--- Active Events ---"), false);
-                            for (ServerEvent event : active) {
-                                long remaining = (event.endTime - System.currentTimeMillis()) / 1000;
-                                context.getSource().sendFeedback(() -> Text.literal("§e" + event.title + " §7(" + event.id.substring(0, 8) + ") - " + event.type + " §f[" + (remaining / 3600) + "h " + ((remaining % 3600) / 60) + "m left]"), false);
-                            }
-                        }
+                        sendEventOverview(context.getSource());
                         return 1;
                     })
+                    .then(CommandManager.argument("id", StringArgumentType.string())
+                        .suggests((context, builder) -> {
+                            suggestActiveEventTitles(builder);
+                            return builder.buildFuture();
+                        })
+                        .executes(context -> {
+                            String input = StringArgumentType.getString(context, "id");
+                            ServerEvent event = EventManager.getInstance().findActiveEventByInput(input);
+                            if (event == null) {
+                                context.getSource().sendError(Text.literal("Event not found. Use /dashboard event list to view active events."));
+                                return 0;
+                            }
+                            sendEventDetail(context.getSource(), event);
+                            return 1;
+                        })
+                    )
                 )
                 .then(CommandManager.literal("clearpoints")
                     .requires(source -> source.hasPermissionLevel(2))
@@ -173,6 +175,30 @@ public class DashboardCommand {
                     )
                 )
                 .then(CommandManager.literal("scoreboard")
+                    .then(CommandManager.literal("hide")
+                        .executes(context -> {
+                            net.minecraft.server.network.ServerPlayerEntity player = context.getSource().getPlayer();
+                            if (player == null) {
+                                context.getSource().sendError(Text.literal("This command must be run by a player."));
+                                return 0;
+                            }
+                            EventManager.getInstance().setScoreboardHidden(player.getUuid(), true);
+                            context.getSource().sendFeedback(() -> Text.literal("§aEvent scoreboard hidden. Use §f/dashboard event scoreboard show§a to bring it back."), false);
+                            return 1;
+                        })
+                    )
+                    .then(CommandManager.literal("show")
+                        .executes(context -> {
+                            net.minecraft.server.network.ServerPlayerEntity player = context.getSource().getPlayer();
+                            if (player == null) {
+                                context.getSource().sendError(Text.literal("This command must be run by a player."));
+                                return 0;
+                            }
+                            EventManager.getInstance().setScoreboardHidden(player.getUuid(), false);
+                            context.getSource().sendFeedback(() -> Text.literal("§aEvent scoreboard shown."), false);
+                            return 1;
+                        })
+                    )
                     .then(CommandManager.argument("id", StringArgumentType.string())
                         .suggests((context, builder) -> {
                             suggestActiveEventTitles(builder);
@@ -186,7 +212,14 @@ public class DashboardCommand {
                                 return 0;
                             }
 
-                            EventManager.getInstance().setPlayerScoreboardPreference(context.getSource().getPlayer().getUuid(), event.id);
+                            net.minecraft.server.network.ServerPlayerEntity player = context.getSource().getPlayer();
+                            if (player == null) {
+                                context.getSource().sendError(Text.literal("This command must be run by a player."));
+                                return 0;
+                            }
+                            EventManager mgr = EventManager.getInstance();
+                            mgr.setScoreboardHidden(player.getUuid(), false);
+                            mgr.setPlayerScoreboardPreference(player.getUuid(), event.id);
                             context.getSource().sendFeedback(() -> Text.literal("§aScoreboard preference set to: " + eventRef(event)), false);
                             return 1;
                         })
@@ -238,5 +271,88 @@ public class DashboardCommand {
     private static String eventRef(ServerEvent event) {
         String title = event.title == null || event.title.isBlank() ? event.id : event.title;
         return title + " (" + shortId(event.id) + ")";
+    }
+
+    private static void sendEventOverview(ServerCommandSource source) {
+        List<ServerEvent> active = EventManager.getInstance().getActiveEvents();
+        if (active == null || active.isEmpty()) {
+            source.sendMessage(Text.literal("§eNo active events."));
+            return;
+        }
+        source.sendMessage(Text.literal("§6--- Active Events (" + active.size() + ") ---"));
+        for (ServerEvent event : active) {
+            long remainingSec = Math.max(0, (event.endTime - System.currentTimeMillis()) / 1000);
+            String remainingStr = formatDuration(remainingSec);
+            int participants = event.currentScores == null ? 0 : (int) event.currentScores.values().stream().filter(v -> v != null && v > 0).count();
+            source.sendMessage(Text.literal(
+                "§e" + (event.title == null ? event.id : event.title)
+                    + " §7(" + shortId(event.id) + ") "
+                    + "§b" + event.type
+                    + " §f[§a" + remainingStr + " left§f] "
+                    + "§7participants: §f" + participants
+            ));
+        }
+    }
+
+    private static void sendEventDetail(ServerCommandSource source, ServerEvent event) {
+        long now = System.currentTimeMillis();
+        long remainingSec = Math.max(0, (event.endTime - now) / 1000);
+        long elapsedSec = Math.max(0, (now - event.startTime) / 1000);
+        long totalSec = Math.max(1, (event.endTime - event.startTime) / 1000);
+        int pct = (int) Math.min(100, Math.max(0, (elapsedSec * 100) / totalSec));
+
+        source.sendMessage(Text.literal("§6--- Event: §e" + (event.title == null ? event.id : event.title) + " §6---"));
+        source.sendMessage(Text.literal("§7id: §f" + event.id));
+        source.sendMessage(Text.literal("§7type: §b" + event.type + (event.lowerIsBetter ? " §7(lower is better)" : "")));
+        source.sendMessage(Text.literal("§7elapsed: §f" + formatDuration(elapsedSec) + " §7/ §f" + formatDuration(totalSec) + " §7(" + pct + "%)"));
+        source.sendMessage(Text.literal("§7remaining: §a" + formatDuration(remainingSec)));
+
+        if (event.currentScores == null || event.currentScores.isEmpty()) {
+            source.sendMessage(Text.literal("§7No scores recorded yet."));
+            return;
+        }
+
+        List<Map.Entry<String, Integer>> ranked = event.currentScores.entrySet().stream()
+            .filter(e -> e.getValue() != null && e.getValue() > 0)
+            .sorted(event.lowerIsBetter ? Map.Entry.comparingByValue() : Map.Entry.<String, Integer>comparingByValue().reversed())
+            .collect(Collectors.toList());
+
+        if (ranked.isEmpty()) {
+            source.sendMessage(Text.literal("§7No qualifying scores yet."));
+            return;
+        }
+
+        int top = Math.min(10, ranked.size());
+        source.sendMessage(Text.literal("§6Top " + top + ":"));
+        EventManager mgr = EventManager.getInstance();
+        for (int i = 0; i < top; i++) {
+            Map.Entry<String, Integer> entry = ranked.get(i);
+            int rank = i + 1;
+            int val = entry.getValue();
+            String name = mgr.resolvePlayerName(entry.getKey());
+            String scoreStr;
+            if (event.type.equals("playtime")) scoreStr = formatDuration(val);
+            else if (event.type.equals("damage_dealt")) scoreStr = val + " ❤";
+            else scoreStr = String.valueOf(val);
+            String pointsStr = rank <= 3 ? " §6(+" + (4 - rank) + " pts)" : "";
+            source.sendMessage(Text.literal("§e#" + rank + " §f" + name + " §7- §a" + scoreStr + pointsStr));
+        }
+        if (ranked.size() > top) {
+            int remaining = ranked.size() - top;
+            source.sendMessage(Text.literal("§7...and " + remaining + " more."));
+        }
+    }
+
+    private static String formatDuration(long seconds) {
+        long d = seconds / 86400;
+        long h = (seconds % 86400) / 3600;
+        long m = (seconds % 3600) / 60;
+        long s = seconds % 60;
+        StringBuilder sb = new StringBuilder();
+        if (d > 0) sb.append(d).append("d ");
+        if (h > 0 || d > 0) sb.append(h).append("h ");
+        if (m > 0 || h > 0 || d > 0) sb.append(m).append("m ");
+        sb.append(s).append("s");
+        return sb.toString();
     }
 }

--- a/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
@@ -13,6 +13,7 @@ import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.scoreboard.*;
 import net.minecraft.scoreboard.number.BlankNumberFormat;
+import net.minecraft.scoreboard.number.FixedNumberFormat;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.stat.StatType;
@@ -33,6 +34,35 @@ import java.util.stream.Collectors;
 public class EventManager {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static EventManager instance;
+
+    private static final Set<String> OBSIDIAN_IDS = Set.of(
+        "minecraft:obsidian",
+        "minecraft:crying_obsidian",
+        "betternether:blue_weeping_obsidian",
+        "betternether:weeping_obsidian",
+        "betternether:blue_crying_obsidian",
+        "betternether:obsidian_bricks",
+        "betternether:obsidian_bricks_stairs",
+        "betternether:obsidian_bricks_slab",
+        "betternether:obsidian_tile",
+        "betternether:obsidian_tile_small",
+        "betternether:obsidian_tile_stairs",
+        "betternether:obsidian_tile_slab",
+        "betternether:obsidian_rod_tiles",
+        "betternether:obsidian_glass",
+        "betternether:obsidian_glass_pane",
+        "betternether:blue_obsidian",
+        "betternether:blue_obsidian_bricks",
+        "betternether:blue_obsidian_bricks_stairs",
+        "betternether:blue_obsidian_bricks_slab",
+        "betternether:blue_obsidian_tile",
+        "betternether:blue_obsidian_tile_small",
+        "betternether:blue_obsidian_tile_stairs",
+        "betternether:blue_obsidian_tile_slab",
+        "betternether:blue_obsidian_rod_tiles",
+        "betternether:blue_obsidian_glass",
+        "betternether:blue_obsidian_glass_pane"
+    );
     private final File eventsFile;
     private MinecraftServer server;
     
@@ -40,6 +70,7 @@ public class EventManager {
     private Map<String, String> playerPreferences = new HashMap<>(); // UUID -> eventId
     private Map<String, Integer> allTimePoints = new HashMap<>();
     private Map<String, Set<UUID>> syncedObjectives = new HashMap<>(); // objName -> set of player UUIDs
+    private Set<String> hiddenScoreboards = new HashSet<>(); // UUIDs of players who hid the sidebar
 
     private EventManager() {
         this.eventsFile = new File(FabricLoader.getInstance().getGameDir().toFile(), "dashboard_events.json");
@@ -60,6 +91,7 @@ public class EventManager {
     }
 
     public List<ServerEvent> getActiveEvents() {
+        if (activeEvents == null) activeEvents = new ArrayList<>();
         return activeEvents;
     }
 
@@ -163,8 +195,8 @@ public class EventManager {
 
         updateScores(eventToStop);
         distributePoints(eventToStop);
-        
-        server.getPlayerManager().broadcast(Text.literal("§6[Event] §cEvent ended: §l" + eventToStop.title), false);
+        broadcastEventResults(eventToStop);
+
         activeEvents.remove(eventToStop);
         
         Scoreboard scoreboard = server.getScoreboard();
@@ -286,8 +318,30 @@ public class EventManager {
             case "daily_streak": return StreakTracker.getInstance().getStreak(player.getUuid().toString());
             case "blocks_placed": return sumCategoryPlayer(player, Stats.USED, true);
             case "blocks_mined": return sumCategoryPlayer(player, Stats.MINED, false);
+            case "obsidian_placed": return sumIdSetFromPlayer(player, true);
+            case "obsidian_mined": return sumIdSetFromPlayer(player, false);
             default: return 0;
         }
+    }
+
+    private int sumIdSetFromPlayer(ServerPlayerEntity player, boolean placed) {
+        int sum = 0;
+        if (placed) {
+            for (Item item : Registries.ITEM) {
+                String id = Registries.ITEM.getId(item).toString();
+                if (OBSIDIAN_IDS.contains(id)) {
+                    sum += player.getStatHandler().getStat(Stats.USED, item);
+                }
+            }
+        } else {
+            for (Block block : Registries.BLOCK) {
+                String id = Registries.BLOCK.getId(block).toString();
+                if (OBSIDIAN_IDS.contains(id)) {
+                    sum += player.getStatHandler().getStat(Stats.MINED, block);
+                }
+            }
+        }
+        return sum;
     }
 
     private int sumCategoryPlayer(ServerPlayerEntity player, StatType<?> type, boolean blocksOnly) {
@@ -323,6 +377,8 @@ public class EventManager {
                 case "daily_streak": return StreakTracker.getInstance().getStreak(statFile.getName().replace(".json", ""));
                 case "blocks_placed": return sumCategory(stats, "minecraft:used", true);
                 case "blocks_mined": return sumCategory(stats, "minecraft:mined", false);
+                case "obsidian_placed": return sumIdSetFromDisk(stats, "minecraft:used");
+                case "obsidian_mined": return sumIdSetFromDisk(stats, "minecraft:mined");
                 default: return 0;
             }
         } catch (Exception e) { return 0; }
@@ -343,6 +399,16 @@ public class EventManager {
         for (String id : cat.keySet()) {
             if (blocksOnly && !id.contains(":")) continue;
             sum += cat.get(id).getAsInt();
+        }
+        return sum;
+    }
+
+    private int sumIdSetFromDisk(JsonObject stats, String category) {
+        if (!stats.has(category)) return 0;
+        JsonObject cat = stats.getAsJsonObject(category);
+        int sum = 0;
+        for (String id : cat.keySet()) {
+            if (OBSIDIAN_IDS.contains(id)) sum += cat.get(id).getAsInt();
         }
         return sum;
     }
@@ -398,6 +464,10 @@ public class EventManager {
 
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
             String uuidStr = player.getUuid().toString();
+            if (hiddenScoreboards != null && hiddenScoreboards.contains(uuidStr)) {
+                player.networkHandler.sendPacket(new ScoreboardDisplayS2CPacket(ScoreboardDisplaySlot.SIDEBAR, null));
+                continue;
+            }
             String prefId = playerPreferences.get(uuidStr);
             ServerEvent displayEvent = activeEvents.stream().filter(e -> e.id.equals(prefId)).findFirst()
                     .orElse(activeEvents.get(0));
@@ -413,8 +483,18 @@ public class EventManager {
 
                 // Force sidebar display
                 player.networkHandler.sendPacket(new ScoreboardDisplayS2CPacket(ScoreboardDisplaySlot.SIDEBAR, obj));
-                
-                int count = 0;
+
+                long remainingMs = displayEvent.endTime - System.currentTimeMillis();
+                int remainingSeconds = (int) Math.max(0, remainingMs / 1000);
+                net.minecraft.text.MutableText timerText = Text.literal("§b§lTime Left: §r§f" + formatTime(remainingSeconds));
+                player.networkHandler.sendPacket(new ScoreboardScoreUpdateS2CPacket(
+                    "_time_remaining_",
+                    obj.getName(),
+                    Integer.MAX_VALUE,
+                    Optional.of(timerText),
+                    Optional.of(BlankNumberFormat.INSTANCE)
+                ));
+
                 Map<String, Integer> scores = displayEvent.currentScores;
                 
                 for (Map.Entry<String, Integer> entry : scores.entrySet()) {
@@ -427,19 +507,16 @@ public class EventManager {
                     if (!glyph.isEmpty()) {
                         text.append(Text.literal(glyph).setStyle(net.minecraft.text.Style.EMPTY.withFont(Identifier.of("dashboard", "heads"))));
                     }
-                    text.append(Text.literal(" §f" + name + " §e" + (displayEvent.type.equals("playtime") ? formatTime(val) : (displayEvent.type.equals("damage_dealt") ? val + " ❤" : val))));
+                    text.append(Text.literal(" §f" + name));
 
                     player.networkHandler.sendPacket(new ScoreboardScoreUpdateS2CPacket(
                         name, 
                         obj.getName(), 
                         internalScore, 
                         Optional.of(text), 
-                        Optional.of(BlankNumberFormat.INSTANCE)
+                        Optional.of(new FixedNumberFormat(Text.literal("§e" + formatScoreValue(displayEvent, val))))
                     ));
-                    count++;
                 }
-                
-                FabricDashboardMod.LOGGER.info("[Scoreboard] Sent {} scores to {} for event {}", count, player.getGameProfile().getName(), displayEvent.title);
             }
         }
     }
@@ -456,10 +533,10 @@ public class EventManager {
             if (!glyph.isEmpty()) {
                 text.append(Text.literal(glyph).setStyle(net.minecraft.text.Style.EMPTY.withFont(Identifier.of("dashboard", "heads"))));
             }
-            text.append(Text.literal(" §f" + name + " §e" + (event.type.equals("playtime") ? formatTime(val) : (event.type.equals("damage_dealt") ? val + " ❤" : val))));
+            text.append(Text.literal(" §f" + name));
             
             score.setDisplayText(text);
-            score.setNumberFormat(BlankNumberFormat.INSTANCE);
+            score.setNumberFormat(new FixedNumberFormat(Text.literal("§e" + formatScoreValue(event, val))));
             score.setScore(event.lowerIsBetter ? Integer.MAX_VALUE - val : val);
         });
     }
@@ -471,10 +548,28 @@ public class EventManager {
         return (d > 0 ? d + "d " : "") + (h > 0 || d > 0 ? h + "h " : "") + (m > 0 || h > 0 || d > 0 ? m + "m " : "") + s + "s";
     }
 
+    private String formatScoreValue(ServerEvent event, int val) {
+        if (event.type.equals("playtime")) return formatTime(val);
+        if (event.type.equals("damage_dealt")) return val + " ❤";
+        return String.valueOf(val);
+    }
+
     public void setPlayerScoreboardPreference(UUID uuid, String eventId) {
         playerPreferences.put(uuid.toString(), eventId);
         save();
         updateScoreboard();
+    }
+
+    public void setScoreboardHidden(UUID uuid, boolean hidden) {
+        String uuidStr = uuid.toString();
+        if (hidden) hiddenScoreboards.add(uuidStr);
+        else hiddenScoreboards.remove(uuidStr);
+        save();
+        updateScoreboard();
+    }
+
+    public boolean isScoreboardHidden(UUID uuid) {
+        return hiddenScoreboards != null && hiddenScoreboards.contains(uuid.toString());
     }
 
     public void clearAllPoints(int amount) {
@@ -494,6 +589,10 @@ public class EventManager {
         if (amount <= 0) allTimePoints.remove(uuidStr);
         else allTimePoints.computeIfPresent(uuidStr, (k, v) -> Math.max(0, v - amount));
         save();
+    }
+
+    public String resolvePlayerName(String uuidStr) {
+        return getPlayerName(uuidStr);
     }
 
     private String getPlayerName(String uuidStr) {
@@ -533,7 +632,12 @@ public class EventManager {
             if (data.has("activeEvents")) activeEvents = GSON.fromJson(data.get("activeEvents"), new TypeToken<List<ServerEvent>>(){}.getType());
             if (data.has("playerPreferences")) playerPreferences = GSON.fromJson(data.get("playerPreferences"), new TypeToken<Map<String, String>>(){}.getType());
             if (data.has("allTimePoints")) allTimePoints = GSON.fromJson(data.get("allTimePoints"), new TypeToken<Map<String, Integer>>(){}.getType());
+            if (data.has("hiddenScoreboards")) hiddenScoreboards = GSON.fromJson(data.get("hiddenScoreboards"), new TypeToken<Set<String>>(){}.getType());
         } catch (Exception e) { FabricDashboardMod.LOGGER.error("Failed to load events data", e); }
+        if (activeEvents == null) activeEvents = new ArrayList<>();
+        if (playerPreferences == null) playerPreferences = new HashMap<>();
+        if (allTimePoints == null) allTimePoints = new HashMap<>();
+        if (hiddenScoreboards == null) hiddenScoreboards = new HashSet<>();
     }
 
     public void save() {
@@ -542,6 +646,7 @@ public class EventManager {
             data.add("activeEvents", GSON.toJsonTree(activeEvents));
             data.add("playerPreferences", GSON.toJsonTree(playerPreferences));
             data.add("allTimePoints", GSON.toJsonTree(allTimePoints));
+            data.add("hiddenScoreboards", GSON.toJsonTree(hiddenScoreboards));
             GSON.toJson(data, writer);
         } catch (IOException e) { FabricDashboardMod.LOGGER.error("Failed to save events data", e); }
     }
@@ -557,5 +662,35 @@ public class EventManager {
             allTimePoints.merge(sorted.get(i).getKey(), 3 - i, Integer::sum);
         }
         save();
+    }
+
+    private void broadcastEventResults(ServerEvent event) {
+        server.getPlayerManager().broadcast(Text.literal("§6[Event] §cEvent ended: §l" + event.title), false);
+
+        List<Map.Entry<String, Integer>> ranked = event.currentScores.entrySet().stream()
+            .filter(entry -> entry.getValue() != null && entry.getValue() > 0)
+            .sorted(event.lowerIsBetter ? Map.Entry.comparingByValue() : Map.Entry.<String, Integer>comparingByValue().reversed())
+            .collect(Collectors.toList());
+
+        if (ranked.isEmpty()) {
+            server.getPlayerManager().broadcast(Text.literal("§7No qualifying scores recorded."), false);
+            return;
+        }
+
+        for (int i = 0; i < ranked.size(); i++) {
+            Map.Entry<String, Integer> entry = ranked.get(i);
+            String playerName = getPlayerName(entry.getKey());
+            int val = entry.getValue();
+            String scoreStr;
+            if (event.type.equals("playtime")) scoreStr = formatTime(val);
+            else if (event.type.equals("damage_dealt")) scoreStr = val + " ❤";
+            else scoreStr = String.valueOf(val);
+            int pointsAwarded = i < 3 ? (3 - i) : 0;
+            String pointsStr = pointsAwarded > 0 ? " §6(+" + pointsAwarded + " pts)" : "";
+            server.getPlayerManager().broadcast(
+                Text.literal("§e#" + (i + 1) + " §f" + playerName + " §7- §a" + scoreStr + pointsStr),
+                false
+            );
+        }
     }
 }

--- a/backend/src/main/resources/web/mc-activity-heatmap-v13.html
+++ b/backend/src/main/resources/web/mc-activity-heatmap-v13.html
@@ -2470,6 +2470,8 @@
               'playtime': 'Playtime (Minutes)',
               'blocks_placed': 'Blocks Placed',
               'blocks_mined': 'Blocks Mined',
+              'obsidian_placed': 'Obsidian Placed',
+              'obsidian_mined': 'Obsidian Mined',
               'mob_kills': 'Mob Kills',
               'fewest_deaths': 'Fewest Deaths',
               'damage_dealt': 'Damage Dealt (Hearts)',

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,11 @@ The mod features an embedded lightweight HTTP server that runs quietly in the ba
 
 ### 🎖️ Server Events & Competitions
 *   **Multiple Concurrent Events**: Run multiple competitions simultaneously (e.g., "Mega Mining Mayhem" and "Playtime Challenge").
-*   **Admin-Driven Events**: Create timed competitions using `/dashboard event create`. Supported types: `playtime`, `mob_kills`, `blocks_placed`, `blocks_mined`, `fewest_deaths`, `damage_dealt`, `player_kills`, `fish_caught`, and `daily_streak`.
+*   **Admin-Driven Events**: Create timed competitions using `/dashboard event create`. Supported types: `playtime`, `mob_kills`, `blocks_placed`, `blocks_mined`, `fewest_deaths`, `damage_dealt`, `player_kills`, `fish_caught`, `daily_streak`, `obsidian_placed`, and `obsidian_mined`.
 *   **Live Scoreboards**: Progress is tracked in real-time on a premium in-game sidebar. Each player can choose which event to track via `/dashboard event scoreboard`.
+    *   **Real-time Timer**: Displays time remaining directly on the sidebar.
+    *   **Sleek Layout**: Scores are right-aligned for better readability.
+    *   **Privacy Controls**: Players can hide/show their personal scoreboard.
 *   **Inverted Leaderboards**: Support for `fewest_deaths` where the lowest score wins, correctly sorted on the Minecraft sidebar.
 *   **Player Head Rendering**: Native rendering of player heads on the sidebar using a dynamic resource pack.
 *   **Web Leaderboard**: A dedicated "Events" tab on the dashboard with individual cards for each active event, live timers, and interactive leaderboards.
@@ -85,9 +88,11 @@ By default, the dashboard is accessible at `http://<your-server-ip>:8105`.
 | `/dashboard event create <type> <hours> <title>` | Start a new timed event. | OP (2) |
 | `/dashboard event stop [id]` | Stop a specific event (or the latest if no ID provided). | OP (2) |
 | `/dashboard event list` | List all active events and their IDs. | All |
-| `/dashboard event status [id]` | View details and remaining time for an event. | All |
+| `/dashboard event status [id]` | View details and remaining time for an event (optional ID for detailed top-10). | All |
 | `/dashboard event setlength <id> <hours>` | Update the duration of an active event. | OP (2) |
-| `/dashboard event scoreboard <id>` | Switch your personal sidebar to track a specific event. | All |
+| `/dashboard event scoreboard <id>` | Switch your personal sidebar to track a specific event (unhides if hidden). | All |
+| `/dashboard event scoreboard hide` | Hide your personal event sidebar. | All |
+| `/dashboard event scoreboard show` | Show your personal event sidebar. | All |
 | `/dashboard event clearpoints all [amount]` | Clear or reduce all-time points for all players. | OP (2) |
 | `/dashboard event clearpoints user <name> [amount]` | Clear or reduce all-time points for a specific player. | OP (2) |
 | `/dashboard reparse` | Force a full re-parse of all server logs to refresh activity data. | OP (2) |

--- a/frontend/mc-activity-heatmap-v13.html
+++ b/frontend/mc-activity-heatmap-v13.html
@@ -2470,6 +2470,8 @@
               'playtime': 'Playtime (Minutes)',
               'blocks_placed': 'Blocks Placed',
               'blocks_mined': 'Blocks Mined',
+              'obsidian_placed': 'Obsidian Placed',
+              'obsidian_mined': 'Obsidian Mined',
               'mob_kills': 'Mob Kills',
               'fewest_deaths': 'Fewest Deaths',
               'damage_dealt': 'Damage Dealt (Hearts)',


### PR DESCRIPTION
### Summary of Changes

This PR introduces significant enhancements to the Server Events system and tracks new block types.

#### 🎖️ Event Scoreboard & UI
- **Real-time Timer**: Added a live countdown timer directly to the in-game scoreboard, positioned just below the event title.
- **Improved Layout**: Player scores are now right-aligned on the scoreboard using Minecraft's `FixedNumberFormat` for a cleaner, professional look.
- **Privacy Controls**: Added `/dashboard event scoreboard hide` and `/dashboard event scoreboard show` commands. These preferences are persisted per-player across server restarts.
- **Auto-Show**: Selecting an event via `/dashboard event scoreboard <id>` now automatically unhides the sidebar for that player.
- **End-of-Event Broadcast**: When an event finishes, the final rankings (scores and points awarded) are broadcast to the entire server chat.

#### 🔍 Command Enhancements
- **Direct Messaging**: `/dashboard event list` and `/dashboard event status` now use direct chat messages instead of command feedback to ensure they are always visible regardless of gamerule settings.
- **Detailed Status**: `/dashboard event status [id]` now provides a detailed breakdown of an event, including total progress, time remaining, and the top 10 ranked players with their projected point rewards.

#### ⛏️ New Event Types
- Added `obsidian_placed` and `obsidian_mined` event types.
- Tracks 26 different obsidian-related blocks from vanilla Minecraft and the **BetterNether** mod.

#### 🛠️ Backend Robustness
- Improved null-safety in `EventManager` when loading active events and preferences.
- Added persistence for hidden scoreboard preferences.

#### 📚 Documentation
- Updated `docs/README.md` to reflect new commands and event types.
- Synchronized frontend changes to `frontend/mc-activity-heatmap-v13.html`.