### PR TITLE
fix: resolve stats path using config and add startup check

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
@@ -109,6 +109,12 @@ public class EventManager {
                 .registerPlayer(player.getUuid(), player.getGameProfile().getName());
         }
         resolveObsidianRegistry();
+        
+        Path statsPath = getStatsPath();
+        if (!java.nio.file.Files.exists(statsPath)) {
+            FabricDashboardMod.LOGGER.warn("[Dashboard] Stats directory not found at: {}. Please check the 'stats_world_name' key in your dashboard-config.json.", statsPath.toAbsolutePath());
+        }
+
         updateScoreboard();
     }
 
@@ -272,7 +278,7 @@ public class EventManager {
     }
 
     private Path getStatsPath() {
-        return server.getRunDirectory().resolve("world/stats");
+        return server.getRunDirectory().resolve(DashboardConfig.get().stats_world_name).resolve("stats");
     }
 
     public void tick() {


### PR DESCRIPTION
This PR fixes the hard-coded `"world"` directory segment in `EventManager.java` and replaces it with the `stats_world_name` configuration value. It also adds a startup check that logs a warning if the resolved stats directory does not exist.

### Changes:
- Updated `EventManager.getStatsPath()` to use `DashboardConfig.get().stats_world_name`.
- Added a directory existence check in `EventManager.init()`.

Closes # [if there was an issue number, but I don't see one mentioned]