### PR TITLE
refactor: unify player ignore logic across components

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -70,6 +70,29 @@ public class DashboardConfig {
         return ignoredOfflineUuids;
     }
 
+    /**
+     * @return true if the player name is in the ignored list (case-insensitive).
+     */
+    public boolean isPlayerIgnored(String name) {
+        if (name == null) return false;
+        return ignoredLowerNames.contains(name.toLowerCase());
+    }
+
+    /**
+     * @return true if the UUID is in the ignored list (as an offline UUID).
+     */
+    public boolean isUuidIgnored(String uuid) {
+        if (uuid == null) return false;
+        return ignoredOfflineUuids.contains(uuid);
+    }
+
+    /**
+     * @return true if either the name or UUID matches the ignored list.
+     */
+    public boolean isIgnored(String name, String uuid) {
+        return isPlayerIgnored(name) || isUuidIgnored(uuid);
+    }
+
     public Map<String, String> getAliasesLower() {
         return aliasesLower;
     }

--- a/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/EventManager.java
@@ -323,11 +323,7 @@ public class EventManager {
     private void updatePlayerScore(ServerEvent event, String uuidStr, int currentValue) {
         String name = getPlayerName(uuidStr);
         DashboardConfig cfg = DashboardConfig.get();
-        if (cfg.getIgnoredLowerNames().contains(name.toLowerCase())) {
-            event.currentScores.remove(uuidStr);
-            return;
-        }
-        if (cfg.getIgnoredOfflineUuids().contains(uuidStr)) {
+        if (cfg.isIgnored(name, uuidStr)) {
             event.currentScores.remove(uuidStr);
             return;
         }

--- a/backend/src/main/java/com/playtime/dashboard/events/StreakTracker.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/StreakTracker.java
@@ -97,6 +97,8 @@ public class StreakTracker {
         UuidCache.getInstance().refresh();
         for (Map.Entry<String, Map<LocalDate, Double>> playerEntry : playerDailyMinutes.entrySet()) {
             String player = playerEntry.getKey();
+            if (DashboardConfig.get().isPlayerIgnored(player)) continue;
+            
             Map<LocalDate, Double> perDay = playerEntry.getValue();
 
             Set<LocalDate> qualifyingDays = new HashSet<>();

--- a/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
+++ b/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
@@ -261,7 +261,7 @@ public class LogParser {
         Matcher joinMatch = JOIN_PATTERN.matcher(line);
         if (joinMatch.find()) {
             String player = normalizePlayer(joinMatch.group(1));
-            if (DashboardConfig.get().ignored_players.contains(player)) return currentTs;
+            if (DashboardConfig.get().isPlayerIgnored(player)) return currentTs;
             
             if (sessions.containsKey(player) && data != null) {
                 closeSession(player, sessions.get(player), currentTs, data);
@@ -273,7 +273,7 @@ public class LogParser {
         Matcher leaveMatch = LEAVE_PATTERN.matcher(line);
         if (leaveMatch.find()) {
             String player = normalizePlayer(leaveMatch.group(1));
-            if (DashboardConfig.get().ignored_players.contains(player)) return currentTs;
+            if (DashboardConfig.get().isPlayerIgnored(player)) return currentTs;
             
             if (sessions.containsKey(player)) {
                 if (data != null) {

--- a/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
+++ b/backend/src/main/java/com/playtime/dashboard/stats/StatsAggregator.java
@@ -66,6 +66,7 @@ public class StatsAggregator {
             String playerName = normalizePlayer(rawName, uuidStr);
             
             if (isUuidString(playerName)) continue;
+            if (com.playtime.dashboard.config.DashboardConfig.get().isIgnored(playerName, uuidStr)) continue;
 
             playerToUuid.putIfAbsent(playerName, uuidStr);
 

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -570,7 +570,7 @@ public class DashboardWebServer {
             }
 
             // Sanitize player name — only allow word characters, slash, and hyphen
-            if (!playerName.matches("[\\w/\\-]+")) {
+            if (!playerName.matches("[\\w/\\-]+") || DashboardConfig.get().isPlayerIgnored(playerName)) {
                 exchange.sendResponseHeaders(400, -1);
                 return;
             }
@@ -637,7 +637,7 @@ public class DashboardWebServer {
             }
             String playerName = filename.substring(0, filename.length() - 4);
 
-            if (!playerName.matches("[\\w/\\-]+")) {
+            if (!playerName.matches("[\\w/\\-]+") || DashboardConfig.get().isPlayerIgnored(playerName)) {
                 exchange.sendResponseHeaders(400, -1);
                 return;
             }
@@ -684,7 +684,14 @@ public class DashboardWebServer {
             }
 
             Map<String, PlayerHeadService.PlayerMeta> metaMap = headService.getColorMap();
-            byte[] json = GSON.toJson(metaMap).getBytes(StandardCharsets.UTF_8);
+            DashboardConfig cfg = DashboardConfig.get();
+            Map<String, PlayerHeadService.PlayerMeta> filtered = new HashMap<>();
+            for (Map.Entry<String, PlayerHeadService.PlayerMeta> entry : metaMap.entrySet()) {
+                if (!cfg.isPlayerIgnored(entry.getKey())) {
+                    filtered.put(entry.getKey(), entry.getValue());
+                }
+            }
+            byte[] json = GSON.toJson(filtered).getBytes(StandardCharsets.UTF_8);
 
             exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
             exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
@@ -748,53 +755,50 @@ public class DashboardWebServer {
             }
 
             try {
-                List<String> ignored = DashboardConfig.get().ignored_players;
-                Set<String> ignoreSet = DashboardConfig.get().getIgnoredLowerNames();
+                DashboardConfig cfg = DashboardConfig.get();
 
-                if (ignored != null && !ignored.isEmpty()) {
-                    if (data.has("sessData")) {
-                        JsonObject sess = data.getAsJsonObject("sessData");
-                        List<String> toRemove = new ArrayList<>();
-                        for (String p : sess.keySet()) {
-                            if (ignoreSet.contains(p.toLowerCase())) toRemove.add(p);
-                        }
-                        for (String p : toRemove) sess.remove(p);
+                if (data.has("sessData")) {
+                    JsonObject sess = data.getAsJsonObject("sessData");
+                    List<String> toRemove = new ArrayList<>();
+                    for (String p : sess.keySet()) {
+                        if (cfg.isPlayerIgnored(p)) toRemove.add(p);
                     }
-
-                    Map<String, Double> newDaily = new HashMap<>();
-                    if (data.has("playerDailyRaw")) {
-                        JsonObject pdr = data.getAsJsonObject("playerDailyRaw");
-                        for (String date : pdr.keySet()) {
-                            JsonObject dayMap = pdr.getAsJsonObject(date);
-                            List<String> toRemove = new ArrayList<>();
-                            for (String p : dayMap.keySet()) {
-                                if (ignoreSet.contains(p.toLowerCase())) toRemove.add(p);
-                            }
-                            for (String p : toRemove) dayMap.remove(p);
-
-                            double sumMinutes = 0;
-                            for (String p : dayMap.keySet()) {
-                                sumMinutes += dayMap.get(p).getAsDouble();
-                            }
-                            newDaily.put(date, Math.round((sumMinutes / 60.0) * 100.0) / 100.0);
-                        }
-                    }
-
-                    if (data.has("hourly")) {
-                        JsonObject hly = data.getAsJsonObject("hourly");
-                        for (String date : hly.keySet()) {
-                            JsonObject dayMap = hly.getAsJsonObject(date);
-                            List<String> toRemove = new ArrayList<>();
-                            for (String p : dayMap.keySet()) {
-                                if (ignoreSet.contains(p.toLowerCase())) toRemove.add(p);
-                            }
-                            for (String p : toRemove) dayMap.remove(p);
-                        }
-                    }
-
-                    data.add("daily", GSON.toJsonTree(newDaily));
-                    data.add("ignored_players", GSON.toJsonTree(ignored));
+                    for (String p : toRemove) sess.remove(p);
                 }
+
+                Map<String, Double> newDaily = new HashMap<>();
+                if (data.has("playerDailyRaw")) {
+                    JsonObject pdr = data.getAsJsonObject("playerDailyRaw");
+                    for (String date : pdr.keySet()) {
+                        JsonObject dayMap = pdr.getAsJsonObject(date);
+                        List<String> toRemove = new ArrayList<>();
+                        for (String p : dayMap.keySet()) {
+                            if (cfg.isPlayerIgnored(p)) toRemove.add(p);
+                        }
+                        for (String p : toRemove) dayMap.remove(p);
+
+                        double sumMinutes = 0;
+                        for (String p : dayMap.keySet()) {
+                            sumMinutes += dayMap.get(p).getAsDouble();
+                        }
+                        newDaily.put(date, Math.round((sumMinutes / 60.0) * 100.0) / 100.0);
+                    }
+                }
+
+                if (data.has("hourly")) {
+                    JsonObject hly = data.getAsJsonObject("hourly");
+                    for (String date : hly.keySet()) {
+                        JsonObject dayMap = hly.getAsJsonObject(date);
+                        List<String> toRemove = new ArrayList<>();
+                        for (String p : dayMap.keySet()) {
+                            if (cfg.isPlayerIgnored(p)) toRemove.add(p);
+                        }
+                        for (String p : toRemove) dayMap.remove(p);
+                    }
+                }
+
+                data.add("daily", GSON.toJsonTree(newDaily));
+                data.add("ignored_players", GSON.toJsonTree(cfg.ignored_players));
 
                 exchange.sendResponseHeaders(200, 0);
                 try (OutputStream raw = exchange.getResponseBody();

--- a/backend/src/main/java/com/playtime/dashboard/web/EventsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/EventsHandler.java
@@ -28,13 +28,21 @@ public class EventsHandler implements HttpHandler {
         java.util.List<ServerEvent> activeEvents = manager.getActiveEvents();
         Map<String, Integer> allTime = manager.getAllTimePoints();
 
+        DashboardConfig cfg = DashboardConfig.get();
+        Map<String, Integer> allTimeFiltered = new HashMap<>();
+        for (Map.Entry<String, Integer> entry : allTime.entrySet()) {
+            if (!cfg.isIgnored(manager.resolvePlayerName(entry.getKey()), entry.getKey())) {
+                allTimeFiltered.put(entry.getKey(), entry.getValue());
+            }
+        }
+
         JsonObject response = new JsonObject();
-        Set<String> allUuids = new HashSet<>(allTime.keySet());
+        Set<String> allUuids = new HashSet<>(allTimeFiltered.keySet());
         response.add("activeEvents", GSON.toJsonTree(activeEvents));
         for (ServerEvent event : activeEvents) {
             allUuids.addAll(event.currentScores.keySet());
         }
-        response.add("allTimePoints", GSON.toJsonTree(allTime));
+        response.add("allTimePoints", GSON.toJsonTree(allTimeFiltered));
         response.add("streaks", GSON.toJsonTree(com.playtime.dashboard.events.StreakTracker.getInstance().getStreaks()));
         response.add("uuidToName", GSON.toJsonTree(manager.resolveNames(allUuids)));
 

--- a/backend/src/main/java/com/playtime/dashboard/web/LeaderboardHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/LeaderboardHandler.java
@@ -50,19 +50,15 @@ public class LeaderboardHandler implements HttpHandler {
 
         try (Reader reader = new FileReader(leaderboardCacheFile)) {
             JsonObject data = JsonParser.parseReader(reader).getAsJsonObject();
-            List<String> ignored = DashboardConfig.get().ignored_players;
+            DashboardConfig cfg = DashboardConfig.get();
 
-            if (ignored != null && !ignored.isEmpty()) {
-                Set<String> ignoreSet = new HashSet<>();
-                for (String s : ignored) ignoreSet.add(s.toLowerCase());
-
-                for (Map.Entry<String, com.google.gson.JsonElement> categoryEntry : data.entrySet()) {
+            for (Map.Entry<String, com.google.gson.JsonElement> categoryEntry : data.entrySet()) {
                     JsonObject categoryMap = categoryEntry.getValue().getAsJsonObject();
                     for (Map.Entry<String, com.google.gson.JsonElement> statEntry : categoryMap.entrySet()) {
                         JsonObject statMap = statEntry.getValue().getAsJsonObject();
                         Set<String> toRemove = new HashSet<>();
                         for (String p : statMap.keySet()) {
-                            if (ignoreSet.contains(p.toLowerCase())) {
+                            if (cfg.isPlayerIgnored(p)) {
                                 toRemove.add(p);
                             }
                         }
@@ -71,7 +67,6 @@ public class LeaderboardHandler implements HttpHandler {
                         }
                     }
                 }
-            }
 
             byte[] json = GSON.toJson(data).getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, json.length);

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerAdvancementsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerAdvancementsHandler.java
@@ -44,6 +44,11 @@ public class PlayerAdvancementsHandler implements HttpHandler {
             return;
         }
 
+        if (DashboardConfig.get().isPlayerIgnored(username)) {
+            sendError(exchange, 404, "Player not found");
+            return;
+        }
+
         exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
         exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
         exchange.getResponseHeaders().set("Pragma", "no-cache");

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
@@ -109,6 +109,7 @@ public class PlayerHeadService {
     /** Schedule a single player fetch if stale or missing. Deduplicated via inFlight set. */
     public void fetchIfNeeded(String playerName) {
         if (!DashboardConfig.get().fetch_player_heads) return;
+        if (DashboardConfig.get().isPlayerIgnored(playerName)) return;
         PlayerMeta existing = metaMap.get(playerName);
         if (existing != null) {
             // Force re-fetch if full skin file is missing (new feature migration)

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerStatsHandler.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerStatsHandler.java
@@ -45,6 +45,11 @@ public class PlayerStatsHandler implements HttpHandler {
             return;
         }
 
+        if (DashboardConfig.get().isPlayerIgnored(username)) {
+            sendError(exchange, 404, "Player not found");
+            return;
+        }
+
         exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
         exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
         exchange.getResponseHeaders().set("Pragma", "no-cache");


### PR DESCRIPTION
This PR refactors the player ignore logic to ensure a consistent, case-insensitive contract across all dashboard components.

### Key Changes
- Centralized ignore checks in `DashboardConfig` using precomputed `ignoredLowerNames` and `ignoredOfflineUuids`.
- Added helper methods `isPlayerIgnored(name)`, `isUuidIgnored(uuid)`, and `isIgnored(name, uuid)` to `DashboardConfig`.
- Updated all call sites in `LogParser`, `EventManager`, `StatsAggregator`, `StreakTracker`, and all web handlers to use the new centralized methods.
- Removed redundant manual set construction and case-sensitive checks in `LeaderboardHandler` and `DashboardWebServer`.
- Added ignore filtering to `PlayerHeadService` to optimize resource usage.
- Enforced 404 responses for ignored players in `PlayerStatsHandler` and `PlayerAdvancementsHandler`.

### Verification
- Verified that all components now respect the same ignore list.
- Verified that both player names and UUIDs are correctly handled where relevant.
- Verified that the API remains consistent and excludes ignored players from activity and leaderboard data.