### PR TITLE
feat: configurable streak thresholds and timezone validation

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -43,6 +43,8 @@ public class DashboardConfig {
     public String resource_pack_url = "http://149.56.155.7:8105/respack.zip"; // Sets resource-pack in server.properties if not empty
     public int max_concurrent_events = 3;
     public String streak_timezone = "America/Toronto";
+    public int streak_minimum_minutes_per_day = 60;
+    public int streak_cache_ttl_minutes = -1; // -1 means inherit incremental_update_interval_minutes
     public boolean allow_pvp_events = true;
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
@@ -60,6 +62,10 @@ public class DashboardConfig {
             load();
         }
         return instance;
+    }
+
+    public int getStreakCacheTtlMinutes() {
+        return streak_cache_ttl_minutes > 0 ? streak_cache_ttl_minutes : incremental_update_interval_minutes;
     }
 
     public Set<String> getIgnoredLowerNames() {
@@ -98,6 +104,14 @@ public class DashboardConfig {
     }
 
     private void recomputeDerived() {
+        // Validate timezone
+        try {
+            java.time.ZoneId.of(streak_timezone);
+        } catch (java.time.DateTimeException e) {
+            FabricDashboardMod.LOGGER.error("Invalid config key 'streak_timezone': {}. Falling back to UTC.", streak_timezone);
+            streak_timezone = "UTC";
+        }
+
         Set<String> names = new HashSet<>();
         Set<String> offlineUuids = new HashSet<>();
         if (ignored_players != null) {

--- a/backend/src/main/java/com/playtime/dashboard/events/StreakTracker.java
+++ b/backend/src/main/java/com/playtime/dashboard/events/StreakTracker.java
@@ -55,7 +55,8 @@ public class StreakTracker {
         ZoneId zone = ZoneId.of(DashboardConfig.get().streak_timezone);
         LocalDate today = LocalDate.now(zone);
         long fileMtime = cacheFile.exists() ? cacheFile.lastModified() : 0L;
-        long ttlNanos = Math.max(1, DashboardConfig.get().incremental_update_interval_minutes) * 60L * 1_000_000_000L;
+        long ttlMinutes = DashboardConfig.get().getStreakCacheTtlMinutes();
+        long ttlNanos = Math.max(1, ttlMinutes) * 60L * 1_000_000_000L;
         long now = System.nanoTime();
 
         Snapshot snap = cachedSnapshot;
@@ -103,7 +104,8 @@ public class StreakTracker {
 
             Set<LocalDate> qualifyingDays = new HashSet<>();
             for (Map.Entry<LocalDate, Double> dayEntry : perDay.entrySet()) {
-                if (dayEntry.getValue() != null && dayEntry.getValue() >= 60.0) {
+                double minMins = DashboardConfig.get().streak_minimum_minutes_per_day;
+                if (dayEntry.getValue() != null && dayEntry.getValue() >= minMins) {
                     qualifyingDays.add(dayEntry.getKey());
                 }
             }


### PR DESCRIPTION
This PR refactors the `StreakTracker` to use configuration values instead of hardcoded thresholds.

### Changes:
- Added `streak_minimum_minutes_per_day` (default 60) to `DashboardConfig`.
- Added `streak_cache_ttl_minutes` (default: inherit `incremental_update_interval_minutes`) to `DashboardConfig`.
- Implemented `streak_timezone` validation at load time with fallback to `UTC`.
- Updated `StreakTracker` to utilize these new configuration parameters.

Closes #[Issue Number if any]