### PR TITLE
feat: optimize ApiHandler with ETag, memory cache, and streaming

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
+++ b/backend/src/main/java/com/playtime/dashboard/parser/LogParser.java
@@ -365,10 +365,18 @@ public class LogParser {
             }
         }
         
-        try (Writer writer = new FileWriter(cacheFile)) {
-            GSON.toJson(data, writer);
+        File tempFile = new File(cacheFile.getAbsolutePath() + ".tmp");
+        try {
+            try (Writer writer = new FileWriter(tempFile)) {
+                GSON.toJson(data, writer);
+            }
+            java.nio.file.Files.move(tempFile.toPath(), cacheFile.toPath(), 
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING, 
+                    java.nio.file.StandardCopyOption.ATOMIC_MOVE);
         } catch (Exception e) {
-            FabricDashboardMod.LOGGER.error("Failed to save cache", e);
+            FabricDashboardMod.LOGGER.error("Failed to save cache atomically", e);
+            if (tempFile.exists()) tempFile.delete();
         }
     }
+
 }

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -14,8 +14,10 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.*;
@@ -707,6 +709,11 @@ public class DashboardWebServer {
     private static class ApiHandler implements HttpHandler {
         private final File cacheFile;
         private static final Gson GSON = new Gson();
+        
+        private volatile byte[] cachedResponse;
+        private volatile String cachedEtag;
+        private volatile long lastModifiedSeen = -1;
+        private volatile int lastIgnoredHash = 0;
 
         public ApiHandler(File cacheFile) {
             this.cacheFile = cacheFile;
@@ -719,97 +726,189 @@ public class DashboardWebServer {
                 return;
             }
 
-            exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
-            exchange.getResponseHeaders().set("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-            exchange.getResponseHeaders().set("Pragma", "no-cache");
-            exchange.getResponseHeaders().set("Expires", "0");
+            DashboardConfig cfg = DashboardConfig.get();
+            long currentLastMod = cacheFile.exists() ? cacheFile.lastModified() : 0;
+            int currentIgnoredHash = cfg.ignored_players != null ? cfg.ignored_players.hashCode() : 0;
 
-            boolean useGzip = clientAcceptsGzip(exchange);
-            if (useGzip) {
-                exchange.getResponseHeaders().set("Content-Encoding", "gzip");
+            // 1. Check if we can serve from memory cache
+            if (currentLastMod > 0 && currentLastMod == lastModifiedSeen && currentIgnoredHash == lastIgnoredHash && cachedResponse != null) {
+                String ifNoneMatch = exchange.getRequestHeaders().getFirst("If-None-Match");
+                if (cachedEtag != null && cachedEtag.equals(ifNoneMatch)) {
+                    exchange.sendResponseHeaders(304, -1);
+                    return;
+                }
+                serveCached(exchange, cachedResponse, cachedEtag);
+                return;
+            }
+
+            // 2. Refresh cache (or serve empty if no file)
+            refreshAndServe(exchange, currentLastMod, currentIgnoredHash, cfg);
+        }
+
+        private synchronized void refreshAndServe(HttpExchange exchange, long currentLastMod, int currentIgnoredHash, DashboardConfig cfg) throws IOException {
+            // Double-check under lock
+            if (currentLastMod > 0 && currentLastMod == lastModifiedSeen && currentIgnoredHash == lastIgnoredHash && cachedResponse != null) {
+                serveCached(exchange, cachedResponse, cachedEtag);
+                return;
             }
 
             if (!cacheFile.exists()) {
-                exchange.sendResponseHeaders(200, 0);
-                try (OutputStream raw = exchange.getResponseBody();
-                     OutputStream out = useGzip ? new GZIPOutputStream(raw) : raw;
-                     Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                try (Writer w = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
                      JsonWriter jw = new JsonWriter(w)) {
                     jw.beginObject();
                     jw.name("daily").beginObject().endObject();
                     jw.name("playerDailyRaw").beginObject().endObject();
                     jw.name("sessData").beginObject().endObject();
                     jw.name("hourly").beginObject().endObject();
+                    jw.name("ignored_players").beginArray().endArray();
                     jw.endObject();
                 }
+                updateCache(baos.toByteArray(), "\"0\"", 0, currentIgnoredHash);
+                serveCached(exchange, cachedResponse, cachedEtag);
                 return;
             }
 
-            JsonObject data;
-            try (Reader reader = new FileReader(cacheFile)) {
-                data = JsonParser.parseReader(reader).getAsJsonObject();
+            // Streaming refresh into a memory buffer
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Map<String, Double> newDaily = new HashMap<>();
+            Set<String> ignored = cfg.getIgnoredLowerNames();
+
+            try (JsonReader reader = new JsonReader(new FileReader(cacheFile));
+                 Writer w = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
+                 JsonWriter writer = new JsonWriter(w)) {
+                
+                reader.beginObject();
+                writer.beginObject();
+                
+                while (reader.hasNext()) {
+                    String name = reader.nextName();
+                    if ("sessData".equals(name)) {
+                        writer.name("sessData");
+                        streamFilteredObject(reader, writer, ignored);
+                    } else if ("playerDailyRaw".equals(name)) {
+                        writer.name("playerDailyRaw");
+                        streamFilteredDailyRaw(reader, writer, ignored, newDaily);
+                    } else if ("hourly".equals(name)) {
+                        writer.name("hourly");
+                        streamFilteredHourly(reader, writer, ignored);
+                    } else {
+                        reader.skipValue();
+                    }
+                }
+                
+                // Add computed summary stats and metadata
+                writer.name("daily");
+                GSON.toJson(newDaily, Map.class, writer);
+                
+                writer.name("ignored_players");
+                GSON.toJson(cfg.ignored_players, List.class, writer);
+                
+                writer.endObject();
             } catch (Exception e) {
-                FabricDashboardMod.LOGGER.error("Failed to read cache for API activity", e);
+                FabricDashboardMod.LOGGER.error("Failed to refresh API activity cache", e);
                 exchange.sendResponseHeaders(500, -1);
                 return;
             }
 
-            try {
-                DashboardConfig cfg = DashboardConfig.get();
+            updateCache(baos.toByteArray(), "\"" + currentLastMod + "\"", currentLastMod, currentIgnoredHash);
+            serveCached(exchange, cachedResponse, cachedEtag);
+        }
 
-                if (data.has("sessData")) {
-                    JsonObject sess = data.getAsJsonObject("sessData");
-                    List<String> toRemove = new ArrayList<>();
-                    for (String p : sess.keySet()) {
-                        if (cfg.isPlayerIgnored(p)) toRemove.add(p);
-                    }
-                    for (String p : toRemove) sess.remove(p);
+        private void updateCache(byte[] data, String etag, long lastMod, int ignoredHash) {
+            this.cachedResponse = data;
+            this.cachedEtag = etag;
+            this.lastModifiedSeen = lastMod;
+            this.lastIgnoredHash = ignoredHash;
+        }
+
+        private void streamFilteredObject(JsonReader reader, JsonWriter writer, Set<String> ignored) throws IOException {
+            reader.beginObject();
+            writer.beginObject();
+            while (reader.hasNext()) {
+                String player = reader.nextName();
+                if (ignored.contains(player.toLowerCase())) {
+                    reader.skipValue();
+                } else {
+                    writer.name(player);
+                    // Copy value object without full tree parse
+                    JsonElement val = GSON.fromJson(reader, JsonElement.class);
+                    GSON.toJson(val, writer);
                 }
+            }
+            reader.endObject();
+            writer.endObject();
+        }
 
-                Map<String, Double> newDaily = new HashMap<>();
-                if (data.has("playerDailyRaw")) {
-                    JsonObject pdr = data.getAsJsonObject("playerDailyRaw");
-                    for (String date : pdr.keySet()) {
-                        JsonObject dayMap = pdr.getAsJsonObject(date);
-                        List<String> toRemove = new ArrayList<>();
-                        for (String p : dayMap.keySet()) {
-                            if (cfg.isPlayerIgnored(p)) toRemove.add(p);
-                        }
-                        for (String p : toRemove) dayMap.remove(p);
-
-                        double sumMinutes = 0;
-                        for (String p : dayMap.keySet()) {
-                            sumMinutes += dayMap.get(p).getAsDouble();
-                        }
-                        newDaily.put(date, Math.round((sumMinutes / 60.0) * 100.0) / 100.0);
+        private void streamFilteredDailyRaw(JsonReader reader, JsonWriter writer, Set<String> ignored, Map<String, Double> newDaily) throws IOException {
+            reader.beginObject();
+            writer.beginObject();
+            while (reader.hasNext()) {
+                String date = reader.nextName();
+                writer.name(date);
+                reader.beginObject();
+                writer.beginObject();
+                double sumMinutes = 0;
+                while (reader.hasNext()) {
+                    String player = reader.nextName();
+                    double val = reader.nextDouble();
+                    if (!ignored.contains(player.toLowerCase())) {
+                        writer.name(player);
+                        writer.value(val);
+                        sumMinutes += val;
                     }
                 }
+                reader.endObject();
+                writer.endObject();
+                newDaily.put(date, Math.round((sumMinutes / 60.0) * 100.0) / 100.0);
+            }
+            reader.endObject();
+            writer.endObject();
+        }
 
-                if (data.has("hourly")) {
-                    JsonObject hly = data.getAsJsonObject("hourly");
-                    for (String date : hly.keySet()) {
-                        JsonObject dayMap = hly.getAsJsonObject(date);
-                        List<String> toRemove = new ArrayList<>();
-                        for (String p : dayMap.keySet()) {
-                            if (cfg.isPlayerIgnored(p)) toRemove.add(p);
-                        }
-                        for (String p : toRemove) dayMap.remove(p);
+        private void streamFilteredHourly(JsonReader reader, JsonWriter writer, Set<String> ignored) throws IOException {
+            reader.beginObject();
+            writer.beginObject();
+            while (reader.hasNext()) {
+                String date = reader.nextName();
+                writer.name(date);
+                reader.beginObject();
+                writer.beginObject();
+                while (reader.hasNext()) {
+                    String player = reader.nextName();
+                    if (ignored.contains(player.toLowerCase())) {
+                        reader.skipValue();
+                    } else {
+                        writer.name(player);
+                        JsonElement val = GSON.fromJson(reader, JsonElement.class);
+                        GSON.toJson(val, writer);
                     }
                 }
+                reader.endObject();
+                writer.endObject();
+            }
+            reader.endObject();
+            writer.endObject();
+        }
 
-                data.add("daily", GSON.toJsonTree(newDaily));
-                data.add("ignored_players", GSON.toJsonTree(cfg.ignored_players));
+        private void serveCached(HttpExchange exchange, byte[] data, String etag) throws IOException {
+            exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.getResponseHeaders().set("ETag", etag);
 
+            boolean useGzip = clientAcceptsGzip(exchange);
+            if (useGzip) {
+                exchange.getResponseHeaders().set("Content-Encoding", "gzip");
                 exchange.sendResponseHeaders(200, 0);
                 try (OutputStream raw = exchange.getResponseBody();
-                     OutputStream out = useGzip ? new GZIPOutputStream(raw) : raw;
-                     Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-                     JsonWriter jw = new JsonWriter(w)) {
-                    GSON.toJson(data, jw);
+                     GZIPOutputStream gzos = new GZIPOutputStream(raw)) {
+                    gzos.write(data);
                 }
-            } catch (Exception e) {
-                FabricDashboardMod.LOGGER.error("Failed to serve filtered API activity", e);
-                try { exchange.sendResponseHeaders(500, -1); } catch (IOException ignored) {}
+            } else {
+                exchange.sendResponseHeaders(200, data.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(data);
+                }
             }
         }
 
@@ -822,6 +921,7 @@ public class DashboardWebServer {
             return false;
         }
     }
+
 
     private static class LiveMetricsHandler implements HttpHandler {
         private final DashboardWebServer server;

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -730,7 +730,7 @@ public class DashboardWebServer {
             long currentLastMod = cacheFile.exists() ? cacheFile.lastModified() : 0;
             int currentIgnoredHash = cfg.ignored_players != null ? cfg.ignored_players.hashCode() : 0;
 
-            // 1. Check if we can serve from memory cache
+            // 1. Fast path: check memory cache before locking
             if (currentLastMod > 0 && currentLastMod == lastModifiedSeen && currentIgnoredHash == lastIgnoredHash && cachedResponse != null) {
                 String ifNoneMatch = exchange.getRequestHeaders().getFirst("If-None-Match");
                 if (cachedEtag != null && cachedEtag.equals(ifNoneMatch)) {
@@ -741,17 +741,26 @@ public class DashboardWebServer {
                 return;
             }
 
-            // 2. Refresh cache (or serve empty if no file)
-            refreshAndServe(exchange, currentLastMod, currentIgnoredHash, cfg);
-        }
-
-        private synchronized void refreshAndServe(HttpExchange exchange, long currentLastMod, int currentIgnoredHash, DashboardConfig cfg) throws IOException {
-            // Double-check under lock
-            if (currentLastMod > 0 && currentLastMod == lastModifiedSeen && currentIgnoredHash == lastIgnoredHash && cachedResponse != null) {
-                serveCached(exchange, cachedResponse, cachedEtag);
-                return;
+            // 2. Slow path: Refresh cache with double-checked locking
+            synchronized (this) {
+                // Re-fetch lastModified under lock to ensure we don't race with a file write/rename
+                currentLastMod = cacheFile.exists() ? cacheFile.lastModified() : 0;
+                
+                if (currentLastMod > 0 && currentLastMod == lastModifiedSeen && currentIgnoredHash == lastIgnoredHash && cachedResponse != null) {
+                    // Cache was refreshed by another thread while we were waiting for the lock
+                } else {
+                    refreshCache(currentLastMod, currentIgnoredHash, cfg);
+                }
             }
 
+            if (cachedResponse != null) {
+                serveCached(exchange, cachedResponse, cachedEtag);
+            } else {
+                exchange.sendResponseHeaders(500, -1);
+            }
+        }
+
+        private void refreshCache(long currentLastMod, int currentIgnoredHash, DashboardConfig cfg) throws IOException {
             if (!cacheFile.exists()) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 try (Writer w = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
@@ -765,7 +774,6 @@ public class DashboardWebServer {
                     jw.endObject();
                 }
                 updateCache(baos.toByteArray(), "\"0\"", 0, currentIgnoredHash);
-                serveCached(exchange, cachedResponse, cachedEtag);
                 return;
             }
 
@@ -797,7 +805,7 @@ public class DashboardWebServer {
                     }
                 }
                 
-                // Add computed summary stats and metadata
+                // Append computed summary stats and metadata at the end of the object
                 writer.name("daily");
                 GSON.toJson(newDaily, Map.class, writer);
                 
@@ -807,12 +815,12 @@ public class DashboardWebServer {
                 writer.endObject();
             } catch (Exception e) {
                 FabricDashboardMod.LOGGER.error("Failed to refresh API activity cache", e);
-                exchange.sendResponseHeaders(500, -1);
-                return;
+                // We do NOT update the cache on failure, so concurrent requests will try again
+                // or fallback to whatever was there before if we didn't clear it.
+                throw new IOException("Cache refresh failed", e);
             }
 
             updateCache(baos.toByteArray(), "\"" + currentLastMod + "\"", currentLastMod, currentIgnoredHash);
-            serveCached(exchange, cachedResponse, cachedEtag);
         }
 
         private void updateCache(byte[] data, String etag, long lastMod, int ignoredHash) {


### PR DESCRIPTION
## Summary
Optimized the `/api/activity` endpoint (handled by `ApiHandler`) to reduce server-side resource consumption and improve client polling efficiency. This is the primary endpoint for the dashboard heatmap and activity charts.

## Key Changes
- **Memory Caching**: Implemented a `volatile byte[]` cache for the filtered activity JSON. Requests are now served from memory unless the underlying `dashboard_cache.json` changes.
- **Streaming Pipeline**: Replaced the previous `JsonObject` tree parsing with a streaming `JsonReader` -> `JsonWriter` pipeline for cache refreshes. This eliminates memory spikes for large activity histories.
- **ETag & 304 Support**: Added `ETag` headers based on the file's `lastModified` timestamp, enabling `304 Not Modified` responses for polling clients.
- **Atomic Cache Refreshes**: Used `synchronized` logic to ensure only one thread performs the JSON processing when a file change is detected.
- **On-the-fly Gzip**: Cached bytes are gzipped on-demand to maintain memory efficiency while supporting compressed transfers.

## Performance Impact
- **GC Pressure**: Significant reduction as full JSON parse trees are no longer created per-request.
- **Bandwidth**: `304` responses eliminate unnecessary data transfer for idle dashboards.
- **Latency**: Polling requests now return instantly from memory cache.

## Verification
- Compiled successfully with `./gradlew classes`.
- Verified streaming logic handles nested `sessData`, `playerDailyRaw`, and `hourly` blocks correctly.
- Verified summary `daily` stats are accurately recalculated during the streaming process.
