### PR TITLE
feat: async world-size executor with change detection and debug command

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
+++ b/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
@@ -3,6 +3,8 @@ package com.playtime.dashboard.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.playtime.dashboard.FabricDashboardMod;
+import com.playtime.dashboard.config.DashboardConfig;
 import com.playtime.dashboard.events.EventManager;
 import com.playtime.dashboard.events.ServerEvent;
 import com.playtime.dashboard.web.DashboardWebServer;
@@ -264,6 +266,92 @@ public class DashboardCommand {
                     context.getSource().sendMessage(Text.literal("§eExecutor alive: §f" + execAlive));
                     return 1;
                 })
+                .then(CommandManager.literal("worldsize")
+                    .requires(source -> source.hasPermissionLevel(2))
+                    .executes(context -> {
+                        DashboardWebServer ws = DashboardWebServer.getInstance();
+                        if (ws == null) {
+                            context.getSource().sendError(Text.literal("[Dashboard] Web server is not running."));
+                            return 0;
+                        }
+
+                        long now        = System.currentTimeMillis();
+                        long sizeMb     = ws.getCachedWorldSizeMb();
+                        long lastCheck  = ws.getLastWorldSizeCheck();
+                        boolean isDown  = ws.isWorldSizeExecutorShutdown();
+                        boolean isTerm  = ws.isWorldSizeExecutorTerminated();
+                        int refreshMin  = DashboardConfig.get().world_size_refresh_minutes;
+                        int maxDepth    = DashboardConfig.get().world_size_max_depth;
+                        long refreshMs  = refreshMin * 60_000L;
+
+                        // Elapsed since last submission — compact "Xm Xs" format intentional
+                        // (distinct from formatDuration which targets event durations with days/hours)
+                        String lastStr;
+                        if (lastCheck == 0) {
+                            lastStr = "never";
+                        } else {
+                            long elapsedSec = (now - lastCheck) / 1000;
+                            lastStr = formatElapsed(elapsedSec) + " ago";
+                        }
+
+                        // Time until next submission
+                        String nextStr;
+                        if (lastCheck == 0) {
+                            nextStr = "pending first run";
+                        } else {
+                            long remainMs = (lastCheck + refreshMs) - now;
+                            nextStr = remainMs <= 0 ? "overdue" : "in " + (remainMs / 1000) + "s";
+                        }
+
+                        // Executor status derived from focused boolean accessors only
+                        String execStatus;
+                        if (isTerm)       execStatus = "terminated";
+                        else if (isDown)  execStatus = "shutdown";
+                        else              execStatus = "running";
+
+                        String copyPayload =
+                            "Dashboard Debug: World Size\n" +
+                            "Cached world size: " + sizeMb + " MB\n" +
+                            "Last walk submitted: " + lastStr + "\n" +
+                            "Next walk due: " + nextStr + "\n" +
+                            "Refresh interval: " + refreshMin + " min\n" +
+                            "Max walk depth: " + maxDepth + "\n" +
+                            "Executor status: " + execStatus;
+
+                        Text copyButton = Text.literal(" §7[§bCopy§7]")
+                            .styled(s -> s
+                                .withClickEvent(new ClickEvent(
+                                    ClickEvent.Action.COPY_TO_CLIPBOARD, copyPayload))
+                                .withHoverEvent(new net.minecraft.text.HoverEvent(
+                                    net.minecraft.text.HoverEvent.Action.SHOW_TEXT,
+                                    Text.literal("§7Click to copy debug info"))));
+
+                        ServerCommandSource src = context.getSource();
+                        src.sendMessage(Text.literal("§6--- Dashboard Debug: World Size ---").append(copyButton));
+                        src.sendMessage(Text.literal("§eCached world size: §f" + sizeMb + " MB"));
+                        src.sendMessage(Text.literal("§eLast walk submitted: §f" + lastStr));
+                        src.sendMessage(Text.literal("§eNext walk due: §f" + nextStr));
+                        src.sendMessage(Text.literal("§eRefresh interval: §f" + refreshMin + " min"));
+                        src.sendMessage(Text.literal("§eMax walk depth: §f" + maxDepth));
+                        src.sendMessage(Text.literal("§eExecutor status: §f" + execStatus));
+
+                        // Thread-identity no-op: output goes to server log only, not chat.
+                        // Guarded by shutdown check, with race-condition catch for the narrow
+                        // window between the check and the actual submission.
+                        if (!isDown) {
+                            try {
+                                ws.submitWorldSizeThreadIdentityCheck();
+                                src.sendMessage(Text.literal("§7Thread identity check submitted — see server log."));
+                            } catch (java.util.concurrent.RejectedExecutionException e) {
+                                src.sendMessage(Text.literal("§cThread check skipped — executor rejected task (shutting down)."));
+                            }
+                        } else {
+                            src.sendMessage(Text.literal("§cExecutor is shut down — thread identity check skipped."));
+                        }
+
+                        return 1;
+                    })
+                )
             )
             .then(CommandManager.literal("reload")
                 .requires(source -> source.hasPermissionLevel(2))
@@ -394,5 +482,16 @@ public class DashboardCommand {
         if (m > 0 || h > 0 || d > 0) sb.append(m).append("m ");
         sb.append(s).append("s");
         return sb.toString();
+    }
+
+    /**
+     * Formats an elapsed number of seconds as a compact human-readable string,
+     * e.g. "2m 14s" or "45s". Used by the worldsize debug subcommand.
+     */
+    private static String formatElapsed(long seconds) {
+        long m = seconds / 60;
+        long s = seconds % 60;
+        if (m > 0) return m + "m " + s + "s";
+        return s + "s";
     }
 }

--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -29,6 +29,8 @@ public class DashboardConfig {
     public static final int DEFAULT_LIVE_UPDATE_INTERVAL = 3;
     public static final int DEFAULT_MAX_CONCURRENT_EVENTS = 3;
     public static final int DEFAULT_STREAK_MINIMUM_MINUTES = 60;
+    public static final int DEFAULT_WORLD_SIZE_REFRESH_MINUTES = 30;
+    public static final int DEFAULT_WORLD_SIZE_MAX_DEPTH = 8;
 
     public int config_version = CURRENT_CONFIG_VERSION;
     public int web_port = DEFAULT_WEB_PORT;
@@ -56,6 +58,8 @@ public class DashboardConfig {
     public int streak_minimum_minutes_per_day = DEFAULT_STREAK_MINIMUM_MINUTES;
     public int streak_cache_ttl_minutes = -1; // -1 means inherit incremental_update_interval_minutes
     public boolean allow_pvp_events = true;
+    public int world_size_refresh_minutes = DEFAULT_WORLD_SIZE_REFRESH_MINUTES;
+    public int world_size_max_depth = DEFAULT_WORLD_SIZE_MAX_DEPTH;
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static DashboardConfig instance;
@@ -165,6 +169,9 @@ public class DashboardConfig {
         if (streak_cache_ttl_minutes != -1) {
             streak_cache_ttl_minutes = checkRange("streak_cache_ttl_minutes", streak_cache_ttl_minutes, 1, 1440, -1);
         }
+
+        world_size_refresh_minutes = checkRange("world_size_refresh_minutes", world_size_refresh_minutes, 1, 1440, DEFAULT_WORLD_SIZE_REFRESH_MINUTES);
+        world_size_max_depth = checkRange("world_size_max_depth", world_size_max_depth, 1, 32, DEFAULT_WORLD_SIZE_MAX_DEPTH);
     }
 
     private int checkRange(String key, int value, int min, int max, int defaultValue) {

--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -51,11 +52,15 @@ public class DashboardWebServer {
     private final StatsAggregator statsAggregator;
     private final UuidCache uuidCache;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
+    private final ExecutorService worldSizeExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "dashboard-world-size");
+        t.setDaemon(true);
+        return t;
+    });
     private volatile LiveMetricsSnapshot liveSnapshot;
     private volatile long cachedWorldSizeMb = 0;
     private volatile long lastWorldSizeCheck = 0;
-    private static final long WORLD_SIZE_REFRESH_MS = 30L * 60L * 1000L;
-    private static final int WORLD_SIZE_MAX_DEPTH = 8;
+    private volatile long lastWorldDirModified = -1;
 
     public static class LivePlayerEntry {
         public final String name;
@@ -131,6 +136,42 @@ public class DashboardWebServer {
 
     public static DashboardWebServer getInstance() {
         return instance;
+    }
+
+    /** Returns the last computed world size in MB (0 until the first walk completes). */
+    public long getCachedWorldSizeMb() {
+        return cachedWorldSizeMb;
+    }
+
+    /** Returns the epoch-ms timestamp of the last time a world-size walk was submitted (0 = never). */
+    public long getLastWorldSizeCheck() {
+        return lastWorldSizeCheck;
+    }
+
+    /** Returns true if the world-size executor has been shut down. */
+    public boolean isWorldSizeExecutorShutdown() {
+        return worldSizeExecutor.isShutdown();
+    }
+
+    /** Returns true if the world-size executor has terminated (all tasks finished after shutdown). */
+    public boolean isWorldSizeExecutorTerminated() {
+        return worldSizeExecutor.isTerminated();
+    }
+
+    /**
+     * Submits a no-op task to the world-size executor that logs its thread name and daemon status.
+     * Intended for use by {@code /dashboard debug worldsize} only.
+     *
+     * @throws java.util.concurrent.RejectedExecutionException if the executor has shut down in the
+     *         narrow race window between the caller's {@link #isWorldSizeExecutorShutdown()} check
+     *         and this call. Callers should catch this exception.
+     */
+    public void submitWorldSizeThreadIdentityCheck() {
+        worldSizeExecutor.execute(() ->
+            FabricDashboardMod.LOGGER.info(
+                "[Dashboard/debug] worldSizeExecutor thread: {}, daemon: {}",
+                Thread.currentThread().getName(),
+                Thread.currentThread().isDaemon()));
     }
 
     public void start() {
@@ -296,12 +337,27 @@ public class DashboardWebServer {
             double diskFreeGb = targetDir.getUsableSpace() / (1024.0 * 1024.0 * 1024.0);
             double diskUsedGb = diskTotalGb - diskFreeGb;
 
-            // World Size: bounded walk over the world dir only, refreshed every 30 minutes.
-            if (System.currentTimeMillis() - lastWorldSizeCheck > WORLD_SIZE_REFRESH_MS) {
-                File worldDir = new File(FabricLoader.getInstance().getGameDir().toFile(),
-                        DashboardConfig.get().stats_world_name);
-                cachedWorldSizeMb = calculateDirectorySize(worldDir) / (1024 * 1024);
-                lastWorldSizeCheck = System.currentTimeMillis();
+            // World Size: offload to background executor with change detection
+            long refreshMs = DashboardConfig.get().world_size_refresh_minutes * 60_000L;
+            if (System.currentTimeMillis() - lastWorldSizeCheck > refreshMs) {
+                lastWorldSizeCheck = System.currentTimeMillis(); // set before submit to prevent double-submit
+                worldSizeExecutor.execute(() -> {
+                    try {
+                        File worldDir = new File(FabricLoader.getInstance().getGameDir().toFile(),
+                                DashboardConfig.get().stats_world_name);
+                        if (!worldDir.exists()) return;
+                        
+                        long currentModified = worldDir.lastModified();
+                        if (currentModified == lastWorldDirModified && cachedWorldSizeMb > 0) return;
+
+                        long newMb = calculateDirectorySize(worldDir,
+                                DashboardConfig.get().world_size_max_depth) / (1024 * 1024);
+                        cachedWorldSizeMb = newMb;
+                        lastWorldDirModified = currentModified;
+                    } catch (Exception e) {
+                        FabricDashboardMod.LOGGER.warn("World size background update failed", e);
+                    }
+                });
             }
 
             this.liveSnapshot = new LiveMetricsSnapshot(playersOnline, maxPlayers, playerNames,
@@ -314,14 +370,15 @@ public class DashboardWebServer {
         }
     }
 
-    private long calculateDirectorySize(File directory) {
+
+    private long calculateDirectorySize(File directory, int maxDepth) {
         if (directory == null || !directory.exists() || !directory.isDirectory()) return 0;
         final long[] total = {0L};
         try {
             java.nio.file.Files.walkFileTree(
                 directory.toPath(),
                 java.util.EnumSet.noneOf(java.nio.file.FileVisitOption.class),
-                WORLD_SIZE_MAX_DEPTH,
+                maxDepth,
                 new java.nio.file.SimpleFileVisitor<java.nio.file.Path>() {
                     @Override
                     public java.nio.file.FileVisitResult visitFile(java.nio.file.Path file,
@@ -377,6 +434,14 @@ public class DashboardWebServer {
         }
         if (scheduler != null) {
             scheduler.shutdownNow();
+        }
+        if (worldSizeExecutor != null) {
+            worldSizeExecutor.shutdownNow();
+            try {
+                worldSizeExecutor.awaitTermination(2, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
         }
         if (headService != null) {
             headService.shutdown();

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,8 @@ By default, the dashboard is accessible at `http://<your-server-ip>:8105`.
 | `/dashboard event clearpoints user <name> [amount]` | Clear or reduce all-time points for a specific player. | OP (2) |
 | `/dashboard reparse` | Force a full re-parse of all server logs to refresh activity data. | OP (2) |
 | `/dashboard reload` | Reload the mod configuration. | OP (2) |
+| `/dashboard debug` | Print EventManager persistence health (dirty flag, save counters, executor status). | OP (2) |
+| `/dashboard debug worldsize` | Print world-size executor state: cached size, last/next walk timing, config, and executor status. Submits a thread-identity check to the server log. | OP (2) |
 
 ## Configuration
 Settings are managed via `config/dashboard-config.json`. The file is automatically generated on first run.
@@ -124,6 +126,8 @@ Settings are managed via `config/dashboard-config.json`. The file is automatical
 | `resource_pack_url` | `""` | The URL where clients download the custom font resource pack. | **No (Restart Required)** |
 | `enable_live_tab` | `true` | Toggle the Live Metrics tab on/off. | Yes |
 | `live_update_interval_seconds` | `3` | Frequency of performance metrics polling. | Yes |
+| `world_size_refresh_minutes` | `30` | How often (in minutes) to recompute the world directory size in the background. | Yes |
+| `world_size_max_depth` | `8` | Maximum directory recursion depth for the world size walk. | Yes |
 
 ## Performance & Privacy
 - **Zero Database**: No SQL setup required; uses an optimized JSON flat-file cache.


### PR DESCRIPTION
## Summary

Offloads the recursive world-size directory walk from the shared scheduler thread to a dedicated background executor, adds `lastModified`-based change detection to skip redundant scans, exposes the relevant thresholds as configurable settings, and provides a focused `/dashboard debug worldsize` subcommand for in-game observability — eliminating the need for temporary `LOGGER.info` statements during testing.

---

## Changes

### `DashboardConfig.java`
- Added `world_size_refresh_minutes` (default `30`, range `1–1440`) — how often the background walk is submitted
- Added `world_size_max_depth` (default `8`, range `1–32`) — maximum directory recursion depth for the walk
- Both fields are validated in `validateFields()` via the existing `checkRange()` helper
- Both are read dynamically at runtime; no server restart required

### `DashboardWebServer.java`
- Removed hardcoded `WORLD_SIZE_REFRESH_MS` and `WORLD_SIZE_MAX_DEPTH` constants
- Added `worldSizeExecutor` — a single-thread daemon `ExecutorService` named `dashboard-world-size`, following the `PlayerHeadService` pattern
- `updateLiveMetrics()` now submits the walk to `worldSizeExecutor` instead of running it inline; the timestamp guard (`lastWorldSizeCheck`) is set before submission to prevent double-submission
- Walk is skipped if `worldDir.lastModified()` has not changed since the last result (`lastWorldDirModified` field)
- `calculateDirectorySize()` now accepts an explicit `maxDepth` parameter instead of reading a static constant
- `stop()` shuts down `worldSizeExecutor` with a 2-second `awaitTermination`
- **Accessor surface** (no raw `ExecutorService` exposed):
  - `getCachedWorldSizeMb()` — last computed size in MB
  - `getLastWorldSizeCheck()` — epoch-ms of last walk submission (`0` = never)
  - `isWorldSizeExecutorShutdown()` — boolean status
  - `isWorldSizeExecutorTerminated()` — boolean status
  - `submitWorldSizeThreadIdentityCheck()` — submits a no-op that logs thread name and daemon status; throws `RejectedExecutionException` on race; callers must catch

### `DashboardCommand.java`
- Added `/dashboard debug worldsize` subcommand (OP level 2, explicit `.requires()` on the node)
- Reports 7 lines of state to chat with a `[Copy]` button on the header, matching the existing `/dashboard debug` UX:
  - Cached world size (MB)
  - Last walk submitted (elapsed, e.g. `"2m 14s ago"` or `"never"`)
  - Next walk due (`"in Xs"`, `"overdue"`, or `"pending first run"` if no walk has run yet)
  - Configured refresh interval
  - Configured max depth
  - Executor status (`"running"` / `"shutdown"` / `"terminated"`, `terminated` checked first)
- Submits a thread-identity no-op via `ws.submitWorldSizeThreadIdentityCheck()` and reports result to chat; `RejectedExecutionException` is caught for the shutdown race window
- Added `formatElapsed(long seconds)` private helper producing compact `"Xm Xs"` output (intentionally distinct from the existing `formatDuration` which targets event durations with days/hours)

### `docs/README.md`
- Added `world_size_refresh_minutes` and `world_size_max_depth` to the Configuration table
- Added `/dashboard debug` and `/dashboard debug worldsize` to the Server Commands table

---

## Testing

Use the [risk assessment checklist](#) from the review session:

**Regression (must still work)**
- `/api/live` returns valid JSON with non-zero `worldSizeMb` after one refresh interval
- Live tab updates without freezing (scheduler thread not blocked)
- Server starts and shuts down cleanly with no executor-related errors in console
- Existing config fields (`web_port`, `live_update_interval_seconds`) load and validate correctly

**New behaviour (must now work)**
- Fresh config generates `world_size_refresh_minutes: 30` and `world_size_max_depth: 8`
- Setting `world_size_refresh_minutes: 9999` logs a range-validation warning and falls back to `30`
- `/dashboard debug worldsize` reports all 7 lines with plausible values; `[Copy]` button works
- Server log shows `[Dashboard/debug] worldSizeExecutor thread: dashboard-world-size, daemon: true` after running the debug command
- Setting `world_size_refresh_minutes: 1` → polling `/api/live` every 30s for 3 minutes confirms `worldSizeMb` is stable and non-zero
- Setting `world_size_max_depth: 1` → `worldSizeMb` is ≤ the value seen at depth `8`
