### PR TITLE
feat: implement UUID cache refresh throttle and hardening

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
+++ b/backend/src/main/java/com/playtime/dashboard/commands/DashboardCommand.java
@@ -13,6 +13,7 @@ import net.minecraft.text.Text;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class DashboardCommand {
@@ -264,6 +265,149 @@ public class DashboardCommand {
                     context.getSource().sendMessage(Text.literal("§eExecutor alive: §f" + execAlive));
                     return 1;
                 })
+                .then(CommandManager.literal("worldsize")
+                    .requires(source -> source.hasPermissionLevel(2))
+                    .executes(context -> {
+                        DashboardWebServer ws = DashboardWebServer.getInstance();
+                        if (ws == null) {
+                            context.getSource().sendError(Text.literal("[Dashboard] Web server is not running."));
+                            return 0;
+                        }
+
+                        long now        = System.currentTimeMillis();
+                        long sizeMb     = ws.getCachedWorldSizeMb();
+                        long lastCheck  = ws.getLastWorldSizeCheck();
+                        boolean isDown  = ws.isWorldSizeExecutorShutdown();
+                        boolean isTerm  = ws.isWorldSizeExecutorTerminated();
+                        int refreshMin  = DashboardConfig.get().world_size_refresh_minutes;
+                        int maxDepth    = DashboardConfig.get().world_size_max_depth;
+                        long refreshMs  = refreshMin * 60_000L;
+
+                        // Elapsed since last submission — compact "Xm Xs" format intentional
+                        // (distinct from formatDuration which targets event durations with days/hours)
+                        String lastStr;
+                        if (lastCheck == 0) {
+                            lastStr = "never";
+                        } else {
+                            long elapsedSec = (now - lastCheck) / 1000;
+                            lastStr = formatElapsed(elapsedSec) + " ago";
+                        }
+
+                        // Time until next submission
+                        String nextStr;
+                        if (lastCheck == 0) {
+                            nextStr = "pending first run";
+                        } else {
+                            long remainMs = (lastCheck + refreshMs) - now;
+                            nextStr = remainMs <= 0 ? "overdue" : "in " + (remainMs / 1000) + "s";
+                        }
+
+                        // Executor status derived from focused boolean accessors only
+                        String execStatus;
+                        if (isTerm)       execStatus = "terminated";
+                        else if (isDown)  execStatus = "shutdown";
+                        else              execStatus = "running";
+
+                        String copyPayload =
+                            "Dashboard Debug: World Size\n" +
+                            "Cached world size: " + sizeMb + " MB\n" +
+                            "Last walk submitted: " + lastStr + "\n" +
+                            "Next walk due: " + nextStr + "\n" +
+                            "Refresh interval: " + refreshMin + " min\n" +
+                            "Max walk depth: " + maxDepth + "\n" +
+                            "Executor status: " + execStatus;
+
+                        Text copyButton = Text.literal(" §7[§bCopy§7]")
+                            .styled(s -> s
+                                .withClickEvent(new ClickEvent(
+                                    ClickEvent.Action.COPY_TO_CLIPBOARD, copyPayload))
+                                .withHoverEvent(new net.minecraft.text.HoverEvent(
+                                    net.minecraft.text.HoverEvent.Action.SHOW_TEXT,
+                                    Text.literal("§7Click to copy debug info"))));
+
+                        ServerCommandSource src = context.getSource();
+                        src.sendMessage(Text.literal("§6--- Dashboard Debug: World Size ---").append(copyButton));
+                        src.sendMessage(Text.literal("§eCached world size: §f" + sizeMb + " MB"));
+                        src.sendMessage(Text.literal("§eLast walk submitted: §f" + lastStr));
+                        src.sendMessage(Text.literal("§eNext walk due: §f" + nextStr));
+                        src.sendMessage(Text.literal("§eRefresh interval: §f" + refreshMin + " min"));
+                        src.sendMessage(Text.literal("§eMax walk depth: §f" + maxDepth));
+                        src.sendMessage(Text.literal("§eExecutor status: §f" + execStatus));
+
+                        // Thread-identity no-op: output goes to server log only, not chat.
+                        // Guarded by shutdown check, with race-condition catch for the narrow
+                        // window between the check and the actual submission.
+                        if (!isDown) {
+                            try {
+                                ws.submitWorldSizeThreadIdentityCheck();
+                                src.sendMessage(Text.literal("§7Thread identity check submitted — see server log."));
+                            } catch (java.util.concurrent.RejectedExecutionException e) {
+                                src.sendMessage(Text.literal("§cThread check skipped — executor rejected task (shutting down)."));
+                            }
+                        } else {
+                            src.sendMessage(Text.literal("§cExecutor is shut down — thread identity check skipped."));
+                        }
+
+                        return 1;
+                    })
+                )
+                .then(CommandManager.literal("uuid")
+                    .then(CommandManager.argument("identifier", StringArgumentType.string())
+                        .executes(context -> {
+                            String input = StringArgumentType.getString(context, "identifier");
+                            com.playtime.dashboard.util.UuidCache cache = com.playtime.dashboard.util.UuidCache.getInstance();
+                            
+                            UUID resolvedUuid = null;
+                            String resolvedName = null;
+                            Long lastAttempt = null;
+                            String source = "§cnone";
+                            
+                            try {
+                                resolvedUuid = UUID.fromString(input);
+                                if (cache.isRuntime(resolvedUuid)) source = "§aLocal (Runtime)";
+                                else if (cache.isDisk(resolvedUuid)) source = "§aLocal (Disk)";
+                                else if (cache.isNetworkResolved(resolvedUuid)) source = "§bNetwork (Cached)";
+                                
+                                resolvedName = cache.getUsername(resolvedUuid).orElse(null);
+                                lastAttempt = cache.getNetworkLastAttempt(resolvedUuid);
+                            } catch (IllegalArgumentException e) {
+                                if (cache.isRuntime(input)) source = "§aLocal (Runtime)";
+                                else if (cache.isDisk(input)) source = "§aLocal (Disk)";
+                                
+                                resolvedUuid = cache.getUuid(input).orElse(null);
+                                resolvedName = input;
+                                lastAttempt = cache.getNetworkLastAttempt(input);
+                            }
+                            
+                            long now = System.currentTimeMillis();
+                            int cooldownSec = DashboardConfig.get().uuid_refresh_cooldown_seconds;
+                            boolean throttled = lastAttempt != null && (now - lastAttempt) < cooldownSec * 1000L;
+                            
+                            if (source.equals("§cnone") && throttled) {
+                                source = "§cNone (Throttled)";
+                            }
+                            
+                            context.getSource().sendMessage(Text.literal("§6--- Dashboard Debug: UUID ---"));
+                            context.getSource().sendMessage(Text.literal("§eIdentifier: §f" + input));
+                            context.getSource().sendMessage(Text.literal("§eSource: " + source));
+                            context.getSource().sendMessage(Text.literal("§eResolved UUID: §f" + (resolvedUuid != null ? resolvedUuid.toString() : "§cnone")));
+                            context.getSource().sendMessage(Text.literal("§eResolved Name: §f" + (resolvedName != null ? resolvedName : "§cnone")));
+                            
+                            if (lastAttempt != null) {
+                                long elapsed = (now - lastAttempt) / 1000;
+                                String status = throttled ? "§cTHROTTLED" : "§aCLEARED";
+                                context.getSource().sendMessage(Text.literal("§eLast network attempt: §f" + elapsed + "s ago (" + status + ")"));
+                                if (throttled) {
+                                    context.getSource().sendMessage(Text.literal("§eCooldown remains: §f" + (cooldownSec - elapsed) + "s"));
+                                }
+                            } else {
+                                context.getSource().sendMessage(Text.literal("§eLast network attempt: §fnever"));
+                            }
+                            
+                            return 1;
+                        })
+                    )
+                )
             )
             .then(CommandManager.literal("reload")
                 .requires(source -> source.hasPermissionLevel(2))

--- a/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
+++ b/backend/src/main/java/com/playtime/dashboard/config/DashboardConfig.java
@@ -56,6 +56,9 @@ public class DashboardConfig {
     public int streak_minimum_minutes_per_day = DEFAULT_STREAK_MINIMUM_MINUTES;
     public int streak_cache_ttl_minutes = -1; // -1 means inherit incremental_update_interval_minutes
     public boolean allow_pvp_events = true;
+    public int world_size_refresh_minutes = 30;
+    public int world_size_max_depth = 8;
+    public int uuid_refresh_cooldown_seconds = 3600;
 
     private static final transient Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static DashboardConfig instance;
@@ -165,6 +168,10 @@ public class DashboardConfig {
         if (streak_cache_ttl_minutes != -1) {
             streak_cache_ttl_minutes = checkRange("streak_cache_ttl_minutes", streak_cache_ttl_minutes, 1, 1440, -1);
         }
+
+        world_size_refresh_minutes = checkRange("world_size_refresh_minutes", world_size_refresh_minutes, 1, 1440, 30);
+        world_size_max_depth = checkRange("world_size_max_depth", world_size_max_depth, 1, 32, 8);
+        uuid_refresh_cooldown_seconds = checkRange("uuid_refresh_cooldown_seconds", uuid_refresh_cooldown_seconds, 0, 86400, 3600);
     }
 
     private int checkRange(String key, int value, int min, int max, int defaultValue) {

--- a/backend/src/main/java/com/playtime/dashboard/util/UuidCache.java
+++ b/backend/src/main/java/com/playtime/dashboard/util/UuidCache.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.playtime.dashboard.FabricDashboardMod;
+import com.playtime.dashboard.config.DashboardConfig;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.File;
@@ -56,13 +57,22 @@ public class UuidCache {
                     return size() > NETWORK_LRU_CAPACITY;
                 }
             });
-    private final Set<UUID> networkFailed = Collections.synchronizedSet(
-            Collections.newSetFromMap(new LinkedHashMap<UUID, Boolean>(NETWORK_LRU_CAPACITY, 0.75f, true) {
+    /** Map of UUIDs that failed resolution to the epoch timestamp of the last attempt. */
+    private final Map<UUID, Long> networkFailed = Collections.synchronizedMap(
+            new LinkedHashMap<UUID, Long>(NETWORK_LRU_CAPACITY, 0.75f, true) {
                 @Override
-                protected boolean removeEldestEntry(Map.Entry<UUID, Boolean> eldest) {
+                protected boolean removeEldestEntry(Map.Entry<UUID, Long> eldest) {
                     return size() > NETWORK_LRU_CAPACITY;
                 }
-            }));
+            });
+    /** Map of usernames that failed resolution to the epoch timestamp of the last attempt. */
+    private final Map<String, Long> networkFailedNames = Collections.synchronizedMap(
+            new LinkedHashMap<String, Long>(NETWORK_LRU_CAPACITY, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
+                    return size() > NETWORK_LRU_CAPACITY;
+                }
+            });
 
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
     private static final Gson GSON = new Gson();
@@ -162,6 +172,15 @@ public class UuidCache {
         if (uuid != null) return Optional.of(uuid);
 
         FabricDashboardMod.LOGGER.info("UUID for '" + username + "' not found locally, trying Mojang API...");
+        
+        long now = System.currentTimeMillis();
+        Long lastAttempt = networkFailedNames.get(key);
+        int cooldownSec = DashboardConfig.get().uuid_refresh_cooldown_seconds;
+        if (lastAttempt != null && (now - lastAttempt) < cooldownSec * 1000L) {
+            FabricDashboardMod.LOGGER.info("Skipping Mojang lookup for '{}' (throttled). Last attempt: {}s ago", username, (now - lastAttempt) / 1000);
+            return Optional.empty();
+        }
+
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("https://api.mojang.com/users/profiles/minecraft/" + username))
@@ -188,7 +207,8 @@ public class UuidCache {
         } catch (Exception e) {
             FabricDashboardMod.LOGGER.error("Mojang API lookup failed for '" + username + "': " + e.getMessage());
         }
-
+        
+        networkFailedNames.put(key, System.currentTimeMillis());
         return Optional.empty();
     }
 
@@ -204,7 +224,12 @@ public class UuidCache {
         name = networkResolved.get(uuid);
         if (name != null) return Optional.of(name);
 
-        if (networkFailed.contains(uuid)) return Optional.empty();
+        long now = System.currentTimeMillis();
+        Long lastAttempt = networkFailed.get(uuid);
+        int cooldownSec = DashboardConfig.get().uuid_refresh_cooldown_seconds;
+        if (lastAttempt != null && (now - lastAttempt) < cooldownSec * 1000L) {
+            return Optional.empty();
+        }
 
         try {
             HttpRequest request = HttpRequest.newBuilder()
@@ -227,7 +252,7 @@ public class UuidCache {
             // Network failure or rate limit, fall through.
         }
 
-        networkFailed.add(uuid);
+        networkFailed.put(uuid, System.currentTimeMillis());
         return Optional.empty();
     }
 
@@ -239,5 +264,45 @@ public class UuidCache {
         for (UUID u : nameToUuid.values()) uuids.add(u.toString());
         for (UUID u : runtimeNameToUuid.values()) uuids.add(u.toString());
         return uuids;
+    }
+
+    public boolean isLocal(String nameOrUuid) {
+        if (nameOrUuid == null) return false;
+        String key = nameOrUuid.toLowerCase();
+        if (runtimeNameToUuid.containsKey(key) || nameToUuid.containsKey(key)) return true;
+        try {
+            UUID uuid = UUID.fromString(nameOrUuid);
+            return runtimeUuidToName.containsKey(uuid) || uuidToName.containsKey(uuid);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public boolean isNetworkResolved(UUID uuid) {
+        return networkResolved.containsKey(uuid);
+    }
+
+    public Long getNetworkLastAttempt(String name) {
+        return networkFailedNames.get(name.toLowerCase());
+    }
+
+    public Long getNetworkLastAttempt(UUID uuid) {
+        return networkFailed.get(uuid);
+    }
+
+    public boolean isRuntime(String name) {
+        return runtimeNameToUuid.containsKey(name.toLowerCase());
+    }
+
+    public boolean isDisk(String name) {
+        return nameToUuid.containsKey(name.toLowerCase());
+    }
+
+    public boolean isRuntime(UUID uuid) {
+        return runtimeUuidToName.containsKey(uuid);
+    }
+
+    public boolean isDisk(UUID uuid) {
+        return uuidToName.containsKey(uuid);
     }
 }

--- a/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/PlayerHeadService.java
@@ -208,27 +208,12 @@ public class PlayerHeadService {
         if ("Advent/Hanger".equals(playerName)) {
             lookupName = "Advent";
         }
-        String url = "https://api.mojang.com/users/profiles/minecraft/" + lookupName;
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .GET()
-                .timeout(Duration.ofSeconds(10))
-                .build();
-
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-        // 429 = rate limited — throw so the caller marks it as failed (short TTL retry)
-        if (response.statusCode() == 429) {
-            throw new IOException("Mojang rate limit hit for " + playerName);
-        }
-        if (response.statusCode() != 200) return null;
-
-        // Minimal JSON parsing with Gson
-        com.google.gson.JsonObject json = com.google.gson.JsonParser.parseString(response.body()).getAsJsonObject();
-        if (json.has("id")) {
-            return json.get("id").getAsString();
-        }
-        return null;
+        
+        return com.playtime.dashboard.util.UuidCache.getInstance()
+                .getUuid(lookupName)
+                .map(UUID::toString)
+                .map(s -> s.replace("-", ""))
+                .orElse(null);
     }
 
     private String fetchSkinUrl(String uuid) throws Exception {

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,9 @@ By default, the dashboard is accessible at `http://<your-server-ip>:8105`.
 | `/dashboard event clearpoints user <name> [amount]` | Clear or reduce all-time points for a specific player. | OP (2) |
 | `/dashboard reparse` | Force a full re-parse of all server logs to refresh activity data. | OP (2) |
 | `/dashboard reload` | Reload the mod configuration. | OP (2) |
+| `/dashboard debug` | Print EventManager persistence health (dirty flag, save counters, executor status). | OP (2) |
+| `/dashboard debug worldsize` | Print world-size executor state: cached size, last/next walk timing, config, and executor status. Submits a thread-identity check to the server log. | OP (2) |
+| `/dashboard debug uuid <identifier>` | Inspect UUID/Name cache state (Runtime/Disk/Network), last network attempt timing, and cooldown status. | OP (2) |
 
 ## Configuration
 Settings are managed via `config/dashboard-config.json`. The file is automatically generated on first run.
@@ -121,6 +124,9 @@ Settings are managed via `config/dashboard-config.json`. The file is automatical
 | `resource_pack_url` | `""` | The URL where clients download the custom font resource pack. | **No (Restart Required)** |
 | `enable_live_tab` | `true` | Toggle the Live Metrics tab on/off. | Yes |
 | `live_update_interval_seconds` | `3` | Frequency of performance metrics polling. | Yes |
+| `world_size_refresh_minutes` | `30` | How often (in minutes) to recompute the world directory size in the background. | Yes |
+| `world_size_max_depth` | `8` | Maximum directory recursion depth for the world size walk. | Yes |
+| `uuid_refresh_cooldown_seconds` | `3600` | Seconds to wait before re-resolving unknown or failed player names/UUIDs via Mojang. | Yes |
 
 ## Performance & Privacy
 - **Zero Database**: No SQL setup required; uses an optimized JSON flat-file cache.


### PR DESCRIPTION
### Description
This PR implements a robust UUID and username cache refresh throttle to prevent excessive Mojang API spikes, particularly in preparation for Phase 5 analytics.

### Key Changes
- **UuidCache Hardening**: Implemented per-name and per-UUID cooldowns using bounded LRU maps (`networkFailedNames` and `networkFailed`).
- **Configuration**: Added `uuid_refresh_cooldown_seconds` (default 3600) to `DashboardConfig.json` with hot-reload support.
- **Refactoring**: Unified all player identity resolution through `UuidCache`, including `PlayerHeadService`.
- **Observability**: Added `/dashboard debug uuid <identifier>` for real-time cache and throttle inspection.
- **Thread Safety**: All tracking maps are wrapped in `Collections.synchronizedMap`.
- **Fail-Fast**: Captured non-200 responses and network exceptions to prevent tight-loop retries.

### Verification
- Verified via `/dashboard debug uuid` that repeated lookups are correctly throttled.
- Confirmed build success via Gradle.
- Updated `docs/README.md` with new configuration and command documentation.