### PR TITLE
feat: implement leaderboard diff-rebuild optimization

### DIFF
--- a/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
+++ b/backend/src/main/java/com/playtime/dashboard/web/DashboardWebServer.java
@@ -215,6 +215,28 @@ public class DashboardWebServer {
                         java.nio.file.Path statsDir = FabricLoader.getInstance().getGameDir()
                             .resolve(DashboardConfig.get().stats_world_name)
                             .resolve("stats");
+
+                        // Optimization: Skip rebuild if no stats files have changed
+                        long lastRebuild = leaderboardCacheFile.exists() ? leaderboardCacheFile.lastModified() : 0;
+                        File[] statsFiles = statsDir.toFile().listFiles((d, n) -> n.endsWith(".json"));
+                        // If no cache exists, or stats directory is missing/unreadable, trigger a build attempt.
+                        boolean needsRebuild = (lastRebuild == 0 || statsFiles == null);
+                        
+                        if (!needsRebuild) {
+                            for (File f : statsFiles) {
+                                // Use >= to account for filesystem timestamp resolution (often 1s on ext4).
+                                // This may cause occasional redundant rebuilds but prevents missed updates.
+                                if (f.lastModified() >= lastRebuild) {
+                                    needsRebuild = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!needsRebuild) {
+                            return;
+                        }
+
                         uuidCache.refresh(); // Re-read usercache.json
                         Map<String, Map<String, Map<String, Integer>>> leaderboards = statsAggregator.buildLeaderboards(statsDir, uuidCache);
                         


### PR DESCRIPTION
This PR implements an optimization for the leaderboard aggregation process.

### Changes:
- **Diff-Rebuild**: The system now checks the `lastModified` timestamp of all `.json` files in the `stats` directory before initiating a leaderboard rebuild.
- **Robustness**: Handled cases where the stats directory is missing or unreadable.
- **Precision**: Used `>=` comparison to account for 1-second filesystem resolution (e.g., on ext4), preventing missed updates.
- **Silent Operation**: Rebuilds are skipped silently when no changes are detected to keep logs clean.

### Rationale:
Prevents unnecessary I/O and CPU usage by avoiding full leaderboard rebuilds when player statistics haven't changed.